### PR TITLE
fix: update UIController logic

### DIFF
--- a/MedtrumKit/PumpManager/MedtrumPumpState.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpState.swift
@@ -113,7 +113,7 @@ public class MedtrumPumpState: RawRepresentable {
         tempBasalUnits = nil
         tempBasalDuration = nil
         bolusState = .noBolus
-        alarmSetting = .None
+        alarmSetting = .BeepOnly
         expirationTimer = 1
         notificationAfterActivation = .hours(72)
         previousPatch = nil

--- a/MedtrumKitUI/ViewController/MedtrumKitUICoordinator.swift
+++ b/MedtrumKitUI/ViewController/MedtrumKitUICoordinator.swift
@@ -112,6 +112,16 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
             ))
 
         case .patchSettingsScreen:
+            let nextStep = { self.navigateTo(.pumpBaseSettingsScreen) }
+            let viewModel = PatchSettingsViewModel(pumpManager, updatePatch: false, nextStep: nextStep)
+            return hostingController(rootView: PatchSettingsView(viewModel: viewModel, doDirtyCheck: false))
+
+        case .deactivatePatchScreen:
+            let nextStep = { self.resetNavigationTo(.pumpBaseSettingsScreen) }
+            let viewModel = DeactivatePatchViewModel(pumpManager, nextStep)
+            return hostingController(rootView: PatchDeactivationView(viewModel: viewModel))
+
+        case .pumpBaseSettingsScreen:
             let nextStep = {
                 if let pumpManager = self.pumpManager {
                     pumpManager.state.isOnboarded = true
@@ -124,18 +134,8 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
                     }
                 }
 
-                self.navigateTo(.pumpBaseSettingsScreen)
+                self.navigateTo(.patchPrimingScreen)
             }
-            let viewModel = PatchSettingsViewModel(pumpManager, updatePatch: false, nextStep: nextStep)
-            return hostingController(rootView: PatchSettingsView(viewModel: viewModel, doDirtyCheck: false))
-
-        case .deactivatePatchScreen:
-            let nextStep = { self.resetNavigationTo(.pumpBaseSettingsScreen) }
-            let viewModel = DeactivatePatchViewModel(pumpManager, nextStep)
-            return hostingController(rootView: PatchDeactivationView(viewModel: viewModel))
-
-        case .pumpBaseSettingsScreen:
-            let nextStep = { self.navigateTo(.patchPrimingScreen) }
             let viewModel = PumpBaseSettingsViewModel(pumpManager, nextStep, pumpRemoval)
 
             return hostingController(rootView: PumpBaseSettingsView(viewModel: viewModel))

--- a/MedtrumKitUI/ViewModels/Onboarding/PumpBaseSettingsViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Onboarding/PumpBaseSettingsViewModel.swift
@@ -1,4 +1,5 @@
 class PumpBaseSettingsViewModel: ObservableObject {
+    @Published var isOnboarded = false
     @Published var is300u = false
     @Published var serialNumber: String = ""
     @Published var errorMessage: String = ""
@@ -16,6 +17,7 @@ class PumpBaseSettingsViewModel: ObservableObject {
             return
         }
 
+        isOnboarded = pumpManager.state.isOnboarded
         serialNumber = pumpManager.state.pumpSN.hexEncodedString().uppercased()
         if !pumpManager.state.pumpSN.isEmpty {
             // Only try to decrypt pumpSN if it is valid

--- a/MedtrumKitUI/ViewModels/Settings/PatchSettingsViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Settings/PatchSettingsViewModel.swift
@@ -9,7 +9,7 @@ class PatchSettingsViewModel: ObservableObject {
         didSet { checkDirtyState() }
     }
 
-    @Published var alarmSettings = Double(AlarmSettings.None.rawValue) {
+    @Published var alarmSettings = Double(AlarmSettings.BeepOnly.rawValue) {
         didSet { checkDirtyState() }
     }
 

--- a/MedtrumKitUI/Views/Onboarding/OnboardingWelcomeView.swift
+++ b/MedtrumKitUI/Views/Onboarding/OnboardingWelcomeView.swift
@@ -2,6 +2,8 @@ import LoopKitUI
 import SwiftUI
 
 struct OnboardingWelcomeView: View {
+    @Environment(\.dismissAction) private var dismiss
+
     let nextStep: () -> Void
 
     var body: some View {
@@ -26,5 +28,12 @@ struct OnboardingWelcomeView: View {
         .listStyle(InsetGroupedListStyle())
         .edgesIgnoringSafeArea(.bottom)
         .navigationTitle(LocalizedString("Welcome", comment: "welcome header"))
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(LocalizedString("Cancel", comment: "Cancel button title"), action: {
+                    self.dismiss()
+                })
+            }
+        }
     }
 }

--- a/MedtrumKitUI/Views/Onboarding/PatchActivationView.swift
+++ b/MedtrumKitUI/Views/Onboarding/PatchActivationView.swift
@@ -2,6 +2,7 @@ import LoopKitUI
 import SwiftUI
 
 struct PatchActivationView: View {
+    @Environment(\.dismissAction) private var dismiss
     @ObservedObject var viewModel: PatchActivationViewModel
 
     var body: some View {
@@ -73,6 +74,13 @@ struct PatchActivationView: View {
         .listStyle(InsetGroupedListStyle())
         .edgesIgnoringSafeArea(.bottom)
         .navigationTitle(LocalizedString("Patch activation", comment: "Patch activation header"))
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(LocalizedString("Cancel", comment: "Cancel button title"), action: {
+                    self.dismiss()
+                })
+            }
+        }
     }
 
     @ViewBuilder func supportImage(_ imageName: String) -> some View {

--- a/MedtrumKitUI/Views/Onboarding/PumpBaseSettingsView.swift
+++ b/MedtrumKitUI/Views/Onboarding/PumpBaseSettingsView.swift
@@ -47,14 +47,16 @@ struct PumpBaseSettingsView: View {
         .navigationTitle(LocalizedString("Pump base settings", comment: "Pump base settings header"))
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button(action: {
-                    isShowingDeleteConfirmation = true
-                }) {
-                    Text(LocalizedString("Delete Pump", comment: "Label for PumpManager deletion button"))
-                        .foregroundStyle(guidanceColors.critical)
-                }
-                .actionSheet(isPresented: $isShowingDeleteConfirmation) {
-                    removePumpManagerActionSheet(deleteAction: viewModel.pumpRemovalAction)
+                if viewModel.isOnboarded {
+                    Button(action: {
+                        isShowingDeleteConfirmation = true
+                    }) {
+                        Text(LocalizedString("Delete Pump", comment: "Label for PumpManager deletion button"))
+                            .foregroundStyle(guidanceColors.critical)
+                    }
+                    .actionSheet(isPresented: $isShowingDeleteConfirmation) {
+                        removePumpManagerActionSheet(deleteAction: viewModel.pumpRemovalAction)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Changelog:
- Every page, during onboarding, has either a "Go back" or "Cancel"-button on the top left
- After a pump base serial number has been confirmed, the pumpManager is considered "onboarded", which should remove the "add pump" button
- Delete pump is only shown if pumpManager is "onboarded"
- (also fixed the BeepOnly in the Onboarding flow)