### PR TITLE
Keep screen awake during priming and while PatchPrimingView is visible

### DIFF
--- a/MedtrumKitUI/Views/Onboarding/PatchActivationView.swift
+++ b/MedtrumKitUI/Views/Onboarding/PatchActivationView.swift
@@ -4,7 +4,6 @@ import SwiftUI
 struct PatchActivationView: View {
     @Environment(\.dismissAction) private var dismiss
     @ObservedObject var viewModel: PatchActivationViewModel
-    @State private var isVisible = false
 
     var body: some View {
         VStack {

--- a/MedtrumKitUI/Views/Onboarding/PatchActivationView.swift
+++ b/MedtrumKitUI/Views/Onboarding/PatchActivationView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct PatchActivationView: View {
     @Environment(\.dismissAction) private var dismiss
     @ObservedObject var viewModel: PatchActivationViewModel
+    @State private var isVisible = false
 
     var body: some View {
         VStack {
@@ -81,6 +82,7 @@ struct PatchActivationView: View {
                 })
             }
         }
+        .keepScreenAwake(whenBusy: viewModel.isActivating, alsoWhenVisible: true)
     }
 
     @ViewBuilder func supportImage(_ imageName: String) -> some View {

--- a/MedtrumKitUI/Views/Onboarding/PatchPrimingView.swift
+++ b/MedtrumKitUI/Views/Onboarding/PatchPrimingView.swift
@@ -117,8 +117,12 @@ struct PatchPrimingView: View {
 
     private func applyIdleTimerPolicy() {
         let shouldKeepAwake = isVisible || viewModel.isPriming
-        DispatchQueue.main.async {
+        if Thread.isMainThread {
             UIApplication.shared.isIdleTimerDisabled = shouldKeepAwake
+        } else {
+            DispatchQueue.main.async {
+                UIApplication.shared.isIdleTimerDisabled = shouldKeepAwake
+            }
         }
     }
 

--- a/MedtrumKitUI/Views/Onboarding/PatchPrimingView.swift
+++ b/MedtrumKitUI/Views/Onboarding/PatchPrimingView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct PatchPrimingView: View {
     @ObservedObject var viewModel: PatchPrimingViewModel
+    @State private var isVisible = false
 
     var body: some View {
         VStack {
@@ -99,6 +100,24 @@ struct PatchPrimingView: View {
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarBackButtonHidden(viewModel.isPriming)
         .navigationTitle(LocalizedString("Patch priming", comment: "Priming header"))
+
+        // Visibility lifecycle
+        .onAppear {
+            isVisible = true
+            applyIdleTimerPolicy()
+        }
+        .onDisappear {
+            isVisible = false
+            applyIdleTimerPolicy()
+        }
+        .onChange(of: viewModel.isPriming) { _ in
+            applyIdleTimerPolicy()
+        }
+    }
+
+    private func applyIdleTimerPolicy() {
+        let shouldKeepAwake = isVisible || viewModel.isPriming
+        UIApplication.shared.isIdleTimerDisabled = shouldKeepAwake
     }
 
     @ViewBuilder func supportImage(_ imageName: String) -> some View {

--- a/MedtrumKitUI/Views/Onboarding/PatchPrimingView.swift
+++ b/MedtrumKitUI/Views/Onboarding/PatchPrimingView.swift
@@ -117,7 +117,9 @@ struct PatchPrimingView: View {
 
     private func applyIdleTimerPolicy() {
         let shouldKeepAwake = isVisible || viewModel.isPriming
-        UIApplication.shared.isIdleTimerDisabled = shouldKeepAwake
+        DispatchQueue.main.async {
+            UIApplication.shared.isIdleTimerDisabled = shouldKeepAwake
+        }
     }
 
     @ViewBuilder func supportImage(_ imageName: String) -> some View {

--- a/MedtrumKitUI/Views/Onboarding/PatchPrimingView.swift
+++ b/MedtrumKitUI/Views/Onboarding/PatchPrimingView.swift
@@ -100,30 +100,7 @@ struct PatchPrimingView: View {
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarBackButtonHidden(viewModel.isPriming)
         .navigationTitle(LocalizedString("Patch priming", comment: "Priming header"))
-
-        // Visibility lifecycle
-        .onAppear {
-            isVisible = true
-            applyIdleTimerPolicy()
-        }
-        .onDisappear {
-            isVisible = false
-            applyIdleTimerPolicy()
-        }
-        .onChange(of: viewModel.isPriming) { _ in
-            applyIdleTimerPolicy()
-        }
-    }
-
-    private func applyIdleTimerPolicy() {
-        let shouldKeepAwake = isVisible || viewModel.isPriming
-        if Thread.isMainThread {
-            UIApplication.shared.isIdleTimerDisabled = shouldKeepAwake
-        } else {
-            DispatchQueue.main.async {
-                UIApplication.shared.isIdleTimerDisabled = shouldKeepAwake
-            }
-        }
+        .keepScreenAwake(whenBusy: viewModel.isPriming, alsoWhenVisible: true)
     }
 
     @ViewBuilder func supportImage(_ imageName: String) -> some View {

--- a/MedtrumKitUI/Views/Onboarding/PatchPrimingView.swift
+++ b/MedtrumKitUI/Views/Onboarding/PatchPrimingView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 struct PatchPrimingView: View {
     @ObservedObject var viewModel: PatchPrimingViewModel
-    @State private var isVisible = false
 
     var body: some View {
         VStack {

--- a/MedtrumKitUI/Views/UIHelpers.swift
+++ b/MedtrumKitUI/Views/UIHelpers.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct KeepAwakeModifier: ViewModifier {
+    @State private var isVisible = false
+    let isBusy: Bool
+    let alsoWhenVisible: Bool // when true, keep awake whenever the screen is shown
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                isVisible = true
+                applyIdleTimerPolicy()
+            }
+            .onDisappear {
+                isVisible = false
+                applyIdleTimerPolicy()
+            }
+            .onChange(of: isBusy) { _ in
+                applyIdleTimerPolicy()
+            }
+    }
+
+    private func applyIdleTimerPolicy() {
+        let shouldKeepAwake = (alsoWhenVisible && isVisible) || isBusy
+        if Thread.isMainThread {
+            UIApplication.shared.isIdleTimerDisabled = shouldKeepAwake
+        } else {
+            DispatchQueue.main.async {
+                UIApplication.shared.isIdleTimerDisabled = shouldKeepAwake
+            }
+        }
+    }
+}
+
+extension View {
+    // Default: keep awake when visible OR busy
+    func keepScreenAwake(whenBusy isBusy: Bool, alsoWhenVisible: Bool = true) -> some View {
+        modifier(KeepAwakeModifier(isBusy: isBusy, alsoWhenVisible: alsoWhenVisible))
+    }
+}

--- a/MedtrumKitUI/Views/UIHelpers.swift
+++ b/MedtrumKitUI/Views/UIHelpers.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct KeepAwakeModifier: ViewModifier {
     @State private var isVisible = false
     let isBusy: Bool
-    let alsoWhenVisible: Bool // when true, keep awake whenever the screen is shown
+    let alsoWhenVisible: Bool
 
     func body(content: Content) -> some View {
         content
@@ -33,7 +33,6 @@ struct KeepAwakeModifier: ViewModifier {
 }
 
 extension View {
-    // Default: keep awake when visible OR busy
     func keepScreenAwake(whenBusy isBusy: Bool, alsoWhenVisible: Bool = true) -> some View {
         modifier(KeepAwakeModifier(isBusy: isBusy, alsoWhenVisible: alsoWhenVisible))
     }


### PR DESCRIPTION
This has been implemented in incoming version I guess. Closing it.


This PR prevents the device from dimming/locking during the patch priming flow. 
The screen now stays awake while the PatchPrimingView is visible, or Priming is actively running (viewModel.isPriming == true) When neither condition is true, the app restores the default idle timer behavior.

**Changes**
PatchPrimingView:
Add @State private var isVisible
Add applyIdleTimerPolicy() helper to centralize idle timer control
Hook into onAppear/onDisappear to track visibility
Listen to changes in viewModel.isPriming to update the idle timer accordingly