### PR TITLE
Small improvements

### DIFF
--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -245,7 +245,7 @@ extension PeripheralManager: CBPeripheralDelegate {
 
         let service = peripheral.services?.first(where: { $0.uuid == PeripheralManager.SERVICE_UUID })
         guard let service = service else {
-            let localizedError = "No Metrum service found - " +
+            let localizedError = "No Medtrum service found - " +
                 (peripheral.services?.map(\.uuid.uuidString).joined(separator: ", ") ?? "No services discovered")
             log.error(localizedError)
             completion?(.failedToDiscoverServices(localizedError: localizedError))

--- a/MedtrumKitUI/ViewController/MedtrumKitUICoordinator.swift
+++ b/MedtrumKitUI/ViewController/MedtrumKitUICoordinator.swift
@@ -108,6 +108,7 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
             return hostingController(rootView: InsulinTypeSelector(
                 initialValue: allowedInsulinTypes[0],
                 supportedInsulinTypes: allowedInsulinTypes,
+                showSave: false,
                 didConfirm: nextStep
             ))
 

--- a/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
@@ -26,6 +26,7 @@ class MedtrumKitSettingsViewModel: ObservableObject, PumpManagerStatusObserver {
     @Published var basalRate: Double = 0
     @Published var insulinType: InsulinType = .novolog
     @Published var lastSync = Date.distantPast
+    @Published var patchLifecycleExpiration: Bool = false
     @Published var patchLifecycleProgress: Double = 0
     @Published var patchLifecycleState: PatchLifecycleState = .noPatch
     @Published var patchActivatedAt = Date.distantPast
@@ -38,7 +39,6 @@ class MedtrumKitSettingsViewModel: ObservableObject, PumpManagerStatusObserver {
     @Published var showingHeartbeatWarning = false
     @Published var showingDeleteConfirmation = false
     @Published var previousPatch: PreviousPatch? = nil
-    @Published var patchSessionToken: String? = nil
 
     public let patchSettingsViewModel: PatchSettingsViewModel
 
@@ -122,12 +122,23 @@ class MedtrumKitSettingsViewModel: ObservableObject, PumpManagerStatusObserver {
             return nil
         }
 
+        if patchLifecycleExpiration {
+            return Int((patchExpiresAt.timeIntervalSince1970 - Date.now.timeIntervalSince1970).days.rounded(.towardZero))
+        }
+
         return Int((Date.now.timeIntervalSince1970 - patchActivatedAt.timeIntervalSince1970).days.rounded(.towardZero))
     }
 
     var patchLifecycleHours: Int? {
         guard patchLifecycleState == .active else {
             return nil
+        }
+
+        if patchLifecycleExpiration {
+            return Int(
+                (patchExpiresAt.timeIntervalSince1970 - Date.now.timeIntervalSince1970).hours
+                    .truncatingRemainder(dividingBy: 24).rounded(.towardZero)
+            )
         }
 
         return Int(
@@ -139,6 +150,13 @@ class MedtrumKitSettingsViewModel: ObservableObject, PumpManagerStatusObserver {
     var patchLifecycleMinutes: Int? {
         guard patchLifecycleState == .active else {
             return nil
+        }
+
+        if patchLifecycleExpiration {
+            return Int(
+                (patchExpiresAt.timeIntervalSince1970 - Date.now.timeIntervalSince1970).minutes
+                    .truncatingRemainder(dividingBy: 60).rounded(.towardZero)
+            )
         }
 
         return Int(
@@ -311,7 +329,6 @@ extension MedtrumKitSettingsViewModel {
         pumpBaseSN = state.pumpSN.hexEncodedString().uppercased()
         pumpName = state.pumpName
         patchId = state.patchId.toUInt64()
-        patchSessionToken = state.sessionToken.hexEncodedString()
         usingHeartbeatMode = state.usingHeartbeatMode
         patchState = state.pumpState
         patchStateString = state.pumpState.description
@@ -319,6 +336,7 @@ extension MedtrumKitSettingsViewModel {
         basalType = state.basalState
         basalRate = basalType == .tempBasal ? (state.tempBasalUnits ?? state.currentBaseBasalRate) : state.currentBaseBasalRate
         lastSync = state.lastSync
+        patchLifecycleExpiration = state.expirationTimer == 1
         patchActivatedAt = state.patchActivatedAt
         patchExpiresAt = state.patchExpiresAt ?? state.patchActivatedAt.addingTimeInterval(.hours(80))
         battery = state.battery

--- a/MedtrumKitUI/Views/Settings/InsulinTypeSelector.swift
+++ b/MedtrumKitUI/Views/Settings/InsulinTypeSelector.swift
@@ -8,11 +8,13 @@ struct InsulinTypeSelector: View {
     @State private var insulinType: InsulinType?
     private var supportedInsulinTypes: [InsulinType]
     private var didConfirm: (InsulinType) -> Void
+    private let showSave: Bool
 
-    init(initialValue: InsulinType, supportedInsulinTypes: [InsulinType], didConfirm: @escaping (InsulinType) -> Void) {
+    init(initialValue: InsulinType, supportedInsulinTypes: [InsulinType], showSave: Bool, didConfirm: @escaping (InsulinType) -> Void) {
         _insulinType = State(initialValue: initialValue)
         self.supportedInsulinTypes = supportedInsulinTypes
         self.didConfirm = didConfirm
+        self.showSave = showSave
     }
 
     func continueWithType(_ insulinType: InsulinType?) {
@@ -42,7 +44,11 @@ struct InsulinTypeSelector: View {
             Spacer()
 
             Button(action: { self.continueWithType(insulinType) }) {
-                Text(LocalizedString("Continue", comment: "Continue"))
+                if showSave {
+                    Text(LocalizedString("Save", comment: "save"))
+                } else {
+                    Text(LocalizedString("Continue", comment: "Continue"))
+                }
             }
             .buttonStyle(ActionButtonStyle())
             .padding([.bottom, .horizontal])

--- a/MedtrumKitUI/Views/Settings/InsulinTypeSelector.swift
+++ b/MedtrumKitUI/Views/Settings/InsulinTypeSelector.swift
@@ -10,7 +10,12 @@ struct InsulinTypeSelector: View {
     private var didConfirm: (InsulinType) -> Void
     private let showSave: Bool
 
-    init(initialValue: InsulinType, supportedInsulinTypes: [InsulinType], showSave: Bool, didConfirm: @escaping (InsulinType) -> Void) {
+    init(
+        initialValue: InsulinType,
+        supportedInsulinTypes: [InsulinType],
+        showSave: Bool,
+        didConfirm: @escaping (InsulinType) -> Void
+    ) {
         _insulinType = State(initialValue: initialValue)
         self.supportedInsulinTypes = supportedInsulinTypes
         self.didConfirm = didConfirm

--- a/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
+++ b/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
@@ -13,33 +13,6 @@ struct MedtrumKitSettings: View {
 
     var supportedInsulinTypes: [InsulinType]
 
-    var heartbeatModeToggleWarning: ActionSheet {
-        let message = viewModel.usingHeartbeatMode ?
-            LocalizedString(
-                "Currently, you are using a heartbeat mode. This is needed to keep %1$@ running in the background. This might be interesting if your CGM already provides a heartbeat. It is recommended to keep this feature enabled",
-                comment: "Message warning heartbeat disable (1: app name)"
-            ) :
-            LocalizedString(
-                "Currently, you are NOT using a heartbeat mode. A heartbeat is needed to keep %1$@ running in the background. It is recommended to keep enable this feature",
-                comment: "Message warning heartbeat disable (1: app name)"
-            )
-
-        let enableLabel = viewModel.usingHeartbeatMode ?
-            LocalizedString("Yes, Disable heartbeat mode", comment: "Button text to disable heartbeat mode") :
-            LocalizedString("Yes, Enable heartbeat mode", comment: "Button text to enable heartbeat mode")
-
-        return ActionSheet(
-            title: Text(LocalizedString("Toggle heartbeat mode", comment: "Title for toggle heartbeat mode action sheet.")),
-            message: Text(String(format: message, appName)),
-            buttons: [
-                .default(Text(enableLabel)) {
-                    self.viewModel.toggleHeartbeat()
-                },
-                .cancel(Text(LocalizedString("No, Keep as is", comment: "Button text to cancel actionsheet")))
-            ]
-        )
-    }
-
     var body: some View {
         List {
             Section {
@@ -113,18 +86,16 @@ struct MedtrumKitSettings: View {
                     }
                 }
 
-                if viewModel.usingHeartbeatMode {
-                    Button(action: { viewModel.checkConnection() }) {
-                        HStack {
-                            if viewModel.isConnected {
-                                Text(LocalizedString("Disconnect", comment: "disconnect from patch"))
-                            } else {
-                                Text(LocalizedString("Reconnect", comment: "reconnect to patch"))
-                            }
-                            Spacer()
-                            if viewModel.isReconnecting {
-                                ActivityIndicator(isAnimating: .constant(true), style: .medium)
-                            }
+                Button(action: { viewModel.checkConnection() }) {
+                    HStack {
+                        if viewModel.isConnected {
+                            Text(LocalizedString("Disconnect", comment: "disconnect from patch"))
+                        } else {
+                            Text(LocalizedString("Reconnect", comment: "reconnect to patch"))
+                        }
+                        Spacer()
+                        if viewModel.isReconnecting {
+                            ActivityIndicator(isAnimating: .constant(true), style: .medium)
                         }
                     }
                 }
@@ -178,6 +149,7 @@ struct MedtrumKitSettings: View {
                 NavigationLink(destination: InsulinTypeSelector(
                     initialValue: viewModel.insulinType,
                     supportedInsulinTypes: supportedInsulinTypes,
+                    showSave: true,
                     didConfirm: viewModel.didChangeInsulinType
                 )) {
                     HStack {
@@ -204,12 +176,6 @@ struct MedtrumKitSettings: View {
                     Spacer()
                     Text(viewModel.pumpBaseSN)
                         .foregroundColor(.secondary)
-                }
-                .onLongPressGesture {
-                    viewModel.showingHeartbeatWarning = true
-                }
-                .actionSheet(isPresented: $viewModel.showingHeartbeatWarning) {
-                    heartbeatModeToggleWarning
                 }
                 HStack {
                     Text(LocalizedString("Pump base model", comment: "Text for model"))

--- a/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
+++ b/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
@@ -222,16 +222,6 @@ struct MedtrumKitSettings: View {
                     Text(viewModel.batteryText(for: viewModel.battery))
                         .foregroundColor(.secondary)
                 }
-
-                if let sessionToken = viewModel.patchSessionToken {
-                    HStack {
-                        Text(LocalizedString("Session token", comment: "Text for session token"))
-                            .foregroundColor(Color.primary)
-                        Spacer()
-                        Text(sessionToken)
-                            .foregroundColor(.secondary)
-                    }
-                }
             }
 
             if let previousPatch = viewModel.previousPatch {
@@ -366,8 +356,13 @@ struct MedtrumKitSettings: View {
                 }
             case .active:
                 HStack {
-                    Text(LocalizedString("Age:", comment: "Text shown while patch is active"))
-                        .foregroundStyle(.secondary)
+                    if viewModel.patchLifecycleExpiration {
+                        Text(LocalizedString("Expires in:", comment: "Text shown while patch is active"))
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text(LocalizedString("Age:", comment: "Text shown while patch is active"))
+                            .foregroundStyle(.secondary)
+                    }
                     Spacer()
                     viewModel.patchLifecycleDays.map { days in
                         timeComponent(
@@ -402,8 +397,10 @@ struct MedtrumKitSettings: View {
                 }
             }
 
-            ProgressView(progress: viewModel.patchLifecycleProgress)
-                .padding(.top, -5)
+            if viewModel.patchLifecycleExpiration {
+                ProgressView(progress: viewModel.patchLifecycleProgress)
+                    .padding(.top, -5)
+            }
         }
     }
 

--- a/MedtrumKitUI/Views/Settings/PatchSettingsView.swift
+++ b/MedtrumKitUI/Views/Settings/PatchSettingsView.swift
@@ -150,7 +150,11 @@ struct PatchSettingsView: View {
                 viewModel.save()
             }) {
                 if !viewModel.isUpdating {
-                    Text(LocalizedString("Continue", comment: "Continue"))
+                    if viewModel.updatePatch {
+                        Text(LocalizedString("Save", comment: "save"))
+                    } else {
+                        Text(LocalizedString("Continue", comment: "Continue"))
+                    }
                 } else {
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
                 }


### PR DESCRIPTION
Changelog:
- fix `metrum` typo
- rename action buttons from next to save when outside onboarding flow
- update patch age header
  - When in normal mode, show `Expires in`
  - When in extended mode, show patch age without progress bar