### PR TITLE
capture the initial reservoir value to calculate total insulin delivered

### DIFF
--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -207,6 +207,9 @@ public extension MedtrumPumpManager {
         #if targetEnvironment(simulator)
             pumpDelegate.notify { delegate in
                 self.state.reservoir = Double(Int.random(in: 10 ..< 200))
+                if self.state.initialReservoir == nil {
+                    self.state.initialReservoir = self.state.reservoir
+                }
 
                 delegate?.pumpManager(self, didReadReservoirValue: self.state.reservoir, at: Date.now) { _ in }
 
@@ -779,8 +782,8 @@ public extension MedtrumPumpManager {
                 battery: self.state.battery,
                 activatedAt: self.state.patchActivatedAt,
                 deactivatedAt: Date.now,
-                reservoirLevel: self.state.reservoir,
-                maxInsulin: self.state.pumpName.contains("300U") ? 300 : 200
+                initialReservoirLevel: self.state.initialReservoir,
+                reservoirLevel: self.state.reservoir
             )
 
             self.state.patchId = Data()

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -730,6 +730,7 @@ public extension MedtrumPumpManager {
 
                 self.state.patchId = data.patchId
                 self.state.patchActivatedAt = Date.now
+                self.state.initialReservoir = nil
                 self.state.patchExpiresAt = Date.now.addingTimeInterval(.days(3)).addingTimeInterval(.hours(8))
                 self.notifyStateDidChange()
 

--- a/MedtrumKit/PumpManager/MedtrumPumpState.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpState.swift
@@ -19,8 +19,8 @@ public struct PreviousPatch: Codable {
     public var battery: Double
     public var activatedAt: Date
     public var deactivatedAt: Date
+    public var initialReservoirLevel: Double?
     public var reservoirLevel: Double?
-    public var maxInsulin: Int?
 }
 
 public class MedtrumPumpState: RawRepresentable {
@@ -41,6 +41,7 @@ public class MedtrumPumpState: RawRepresentable {
         pumpTimeSyncedAt = rawValue["pumpTimeSyncedAt"] as? Date ?? Date()
         maxHourlyInsulin = rawValue["maxHourlyInsulin"] as? Double ?? 20
         maxDailyInsulin = rawValue["maxDailyInsulin"] as? Double ?? 100
+        initialReservoir = rawValue["initialReservoir"] as? Double
         reservoir = rawValue["reservoir"] as? Double ?? 0
         battery = rawValue["battery"] as? Double ?? 0
         basalStateSince = rawValue["basalStateSince"] as? Date ?? Date.distantPast
@@ -148,6 +149,7 @@ public class MedtrumPumpState: RawRepresentable {
         value["maxDailyInsulin"] = maxDailyInsulin
         value["basalSchedule"] = basalSchedule.rawValue
         value["bolusState"] = bolusState.rawValue
+        value["initialReservoir"] = initialReservoir
         value["reservoir"] = reservoir
         value["battery"] = battery
         value["basalState"] = basalState.rawValue
@@ -188,6 +190,7 @@ public class MedtrumPumpState: RawRepresentable {
     public var pumpTimeSyncedAt: Date
 
     public var pumpState: PatchState
+    public var initialReservoir: Double?
     public var reservoir: Double
     public var battery: Double
 

--- a/MedtrumKit/PumpManager/StateSyncer.swift
+++ b/MedtrumKit/PumpManager/StateSyncer.swift
@@ -11,6 +11,9 @@ enum StateSyncer {
 
         if let reservoir = syncResponse.reservoir {
             state.reservoir = reservoir
+            if state.initialReservoir == nil {
+                state.initialReservoir = state.reservoir
+            }
             delegate?.pumpManager(pumpManager, didReadReservoirValue: state.reservoir.rounded(toPlaces: 1), at: Date.now) { _ in }
         }
 

--- a/MedtrumKitUI/ViewModels/Onboarding/DeactivatePatchViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Onboarding/DeactivatePatchViewModel.swift
@@ -27,8 +27,8 @@ class DeactivatePatchViewModel: ObservableObject {
                 battery: pumpManager.state.battery,
                 activatedAt: pumpManager.state.patchActivatedAt,
                 deactivatedAt: Date.now,
-                reservoirLevel: pumpManager.state.reservoir,
-                maxInsulin: pumpManager.state.pumpName.contains("300U") ? 300 : 200
+                initialReservoirLevel: pumpManager.state.initialReservoir,
+                reservoirLevel: pumpManager.state.reservoir
             )
 
             #if targetEnvironment(simulator)

--- a/MedtrumKitUI/ViewModels/Onboarding/PatchActivationViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Onboarding/PatchActivationViewModel.swift
@@ -16,6 +16,7 @@ class PatchActivationViewModel: ObservableObject {
             if let pumpManager = pumpManager {
                 // Add some mock data
                 pumpManager.state.patchId = Data([1, 2, 3, 4])
+                pumpManager.state.initialReservoir = nil
                 pumpManager.state.reservoir = 200
                 pumpManager.state.battery = 2.5
                 pumpManager.state.pumpState = .active

--- a/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
@@ -17,6 +17,7 @@ class MedtrumKitSettingsViewModel: ObservableObject, PumpManagerStatusObserver {
     @Published var patchId: UInt64 = 0
     @Published var is300u: Bool = false
     @Published var usingHeartbeatMode = false
+    @Published var initialReservoirLevel: Double? = nil
     @Published var reservoirLevel: Double = 0
     @Published var battery: Double = 0
     @Published var maxReservoirLevel: Double = 1
@@ -332,6 +333,7 @@ extension MedtrumKitSettingsViewModel {
         usingHeartbeatMode = state.usingHeartbeatMode
         patchState = state.pumpState
         patchStateString = state.pumpState.description
+        initialReservoirLevel = state.initialReservoir
         reservoirLevel = state.reservoir
         basalType = state.basalState
         basalRate = basalType == .tempBasal ? (state.tempBasalUnits ?? state.currentBaseBasalRate) : state.currentBaseBasalRate

--- a/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
+++ b/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
@@ -222,6 +222,16 @@ struct MedtrumKitSettings: View {
                     Text(viewModel.batteryText(for: viewModel.battery))
                         .foregroundColor(.secondary)
                 }
+                if let initialReservoirLevel = viewModel.initialReservoirLevel {
+                    HStack {
+                        Text(LocalizedString("Insulin used", comment: "Text for Insulin used"))
+                            .foregroundColor(Color.primary)
+                        Spacer()
+                        Text(viewModel.reservoirText(for: initialReservoirLevel - viewModel.reservoirLevel))
+                            .foregroundColor(.secondary)
+                    }
+                }
+
             }
 
             if let previousPatch = viewModel.previousPatch {
@@ -264,12 +274,12 @@ struct MedtrumKitSettings: View {
                         Text(viewModel.batteryText(for: previousPatch.battery))
                             .foregroundColor(.secondary)
                     }
-                    if let reservoirLevel = previousPatch.reservoirLevel, let maxInsulin = previousPatch.maxInsulin {
+                    if let reservoirLevel = previousPatch.reservoirLevel, let initialReservoirLevel = previousPatch.initialReservoirLevel {
                         HStack {
                             Text(LocalizedString("Insulin used", comment: "Text for Insulin used"))
                                 .foregroundColor(Color.primary)
                             Spacer()
-                            Text(viewModel.reservoirText(for: Double(maxInsulin) - reservoirLevel))
+                            Text(viewModel.reservoirText(for: initialReservoirLevel - reservoirLevel))
                                 .foregroundColor(.secondary)
                         }
                     }


### PR DESCRIPTION
Instead of using the max reservoir (200/300 units) - capture and store the initial reservoir value after patch activation, afterwards use it to calculate the total insulin delivered value.

Note: for patches activated before this change, the delivered insulin value will be inaccurate - it will be relative to the moment when this code is first run (`state.initialReservoir` is set to the current reservoir whenever `state.initialReservoir` is `nil`).


* also display total insulin delivered for the active patch:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1b616e33-4b0b-4fda-8a34-fda02192156a" />
