### PR TITLE
fix: handle bolus completion during BLE disconnect

### DIFF
--- a/Common/UnfinalizedDose.swift
+++ b/Common/UnfinalizedDose.swift
@@ -13,7 +13,7 @@ public class UnfinalizedDose {
     public let insulinType: InsulinType?
     public let automatic: Bool?
 
-    public init(units: Double, duration: TimeInterval, activationType: BolusActivationType, insulinType: InsulinType) {
+    public init(units: Double, duration: TimeInterval, activationType: BolusActivationType, insulinType: InsulinType?) {
         var endTime = Date.now
         endTime.addTimeInterval(duration)
 
@@ -26,11 +26,17 @@ public class UnfinalizedDose {
         automatic = activationType.isAutomatic
     }
 
-    public func toDoseEntry(isMutable: Bool = false) -> DoseEntry {
-        DoseEntry(
+    public func toDoseEntry(isMutable: Bool = false, useEstimatedEndDate: Bool = false) -> DoseEntry {
+        var endDate = isMutable || useEstimatedEndDate ? endDate : Date.now
+        if useEstimatedEndDate, endDate > Date.now {
+            // The endDate of a bolus cannot be in the future...
+            endDate = Date.now
+        }
+
+        return DoseEntry(
             type: .bolus,
             startDate: startDate,
-            endDate: isMutable ? endDate : Date(),
+            endDate: endDate,
             value: value.rounded(toPlaces: 2),
             unit: .units,
             deliveredUnits: isMutable ? nil : deliveredUnits.rounded(toPlaces: 2),

--- a/Common/UnfinalizedDose.swift
+++ b/Common/UnfinalizedDose.swift
@@ -4,30 +4,106 @@ import LoopKit
 public class UnfinalizedDose {
     public typealias RawValue = [String: Any]
 
+    private let logger = MedtrumLogger(category: "UnfinalizedDose")
+
     public let type: DoseType
     public let startDate: Date
-    public let endDate: Date
+    public let estimatedEndDate: Date
     public let unit: DoseUnit
     public let value: Double
     public var deliveredUnits: Double = 0
     public let insulinType: InsulinType?
-    public let automatic: Bool?
+    public let automatic: Bool
 
     public init(units: Double, duration: TimeInterval, activationType: BolusActivationType, insulinType: InsulinType?) {
-        var endTime = Date.now
-        endTime.addTimeInterval(duration)
+        var estimatedEndDate = Date.now
+        estimatedEndDate.addTimeInterval(duration)
 
         type = .bolus
         unit = .units
         value = units
         startDate = Date.now
-        endDate = endTime
+        self.estimatedEndDate = estimatedEndDate
         self.insulinType = insulinType
         automatic = activationType.isAutomatic
     }
 
+    public init?(rawValue: RawValue) {
+        if let rawType = rawValue["type"] as? DoseType.RawValue, let type = DoseType(rawValue: rawType) {
+            self.type = type
+        } else {
+            logger.warning("Couldn't convert type")
+            return nil
+        }
+
+        if let rawUnit = rawValue["unit"] as? DoseUnit.RawValue, let unit = DoseUnit(rawValue: rawUnit) {
+            self.unit = unit
+        } else {
+            logger.warning("Couldn't convert unit")
+            return nil
+        }
+
+        if let value = rawValue["value"] as? Double {
+            self.value = value
+        } else {
+            logger.warning("Couldn't convert value")
+            return nil
+        }
+
+        if let rawStartDate = rawValue["startDate"] as? Date {
+            startDate = rawStartDate
+        } else {
+            logger.warning("Couldn't convert startDate")
+            return nil
+        }
+
+        if let rawEstimatedEndDate = rawValue["estimatedEndDate"] as? Date {
+            estimatedEndDate = rawEstimatedEndDate
+        } else {
+            logger.warning("Couldn't convert estimatedEndDate")
+            return nil
+        }
+
+        if let rawDeliveredUnits = rawValue["deliveredUnits"] as? Double {
+            deliveredUnits = rawDeliveredUnits
+        } else {
+            logger.warning("Couldn't convert deliveredUnits")
+            return nil
+        }
+
+        if let rawInsulinType = rawValue["insulinType"] as? InsulinType.RawValue,
+           let insulinType = InsulinType(rawValue: rawInsulinType)
+        {
+            self.insulinType = insulinType
+        } else {
+            insulinType = nil
+        }
+
+        if let rawAutomatic = rawValue["automatic"] as? Bool {
+            automatic = rawAutomatic
+        } else {
+            logger.warning("Couldn't convert automatic")
+            return nil
+        }
+    }
+
+    public var rawValue: RawValue {
+        var raw: RawValue = [:]
+
+        raw["type"] = type.rawValue
+        raw["unit"] = unit.rawValue
+        raw["value"] = value
+        raw["startDate"] = startDate
+        raw["estimatedEndDate"] = estimatedEndDate
+        raw["deliveredUnits"] = deliveredUnits
+        raw["insulinType"] = insulinType?.rawValue
+        raw["automatic"] = automatic
+
+        return raw
+    }
+
     public func toDoseEntry(isMutable: Bool = false, useEstimatedEndDate: Bool = false) -> DoseEntry {
-        var endDate = isMutable || useEstimatedEndDate ? endDate : Date.now
+        var endDate = isMutable || useEstimatedEndDate ? estimatedEndDate : Date.now
         if useEstimatedEndDate, endDate > Date.now {
             // The endDate of a bolus cannot be in the future...
             endDate = Date.now

--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -182,7 +182,27 @@ extension BluetoothManager {
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         logger.info("\(String(describing: central.state.rawValue))")
 
-        if central.state == .poweredOn, !isConnected, pumpManager?.state.pumpState == .active {
+        guard central.state == .poweredOn else {
+            return
+        }
+
+        if let peripheral = self.peripheral {
+            logger.info("Reconnecting to restored state...")
+            connectCompletion = { (error: MedtrumConnectError?) -> Void in
+                if let error = error {
+                    self.logger.error("Failed to restore state: \(error)")
+                } else {
+                    self.logger.info("Restored state!")
+                }
+
+                self.connectCompletion = nil
+            }
+
+            connect(peripheral: peripheral)
+            return
+        }
+
+        if !isConnected, pumpManager?.state.pumpState == .active {
             ensureConnected { error in
                 if let error = error {
                     self.logger.error("Failed to auto reconnect on boot: \(error)")
@@ -268,20 +288,7 @@ extension BluetoothManager {
             return
         }
 
-        logger.info("Restoring state to: \(peripheral.identifier.uuidString)")
-        let peripheralManager = PeripheralManager(peripheral, self, pumpManager) { reconnectResult in
-            if let error = reconnectResult {
-                self.logger.warning("Couldnt reconnect to pump: \(error)")
-                return
-            }
-
-            self.logger.info("Reconnected to patch using restored state!")
-        }
-
         self.peripheral = peripheral
-        self.peripheralManager = peripheralManager
-
-        peripheralManager.peripheral(peripheral, didDiscoverCharacteristicsFor: service, error: nil)
     }
 
     func centralManager(_: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {

--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -276,13 +276,7 @@ extension BluetoothManager {
             return
         }
 
-        guard let pumpManager = pumpManager else {
-            logger.warning("Couldnt restore state, since no pumpManager is available...")
-            centralManager.cancelPeripheralConnection(peripheral)
-            return
-        }
-
-        guard let service = peripheral.services?.first(where: { $0.uuid == PeripheralManager.SERVICE_UUID }) else {
+        if peripheral.services?.first(where: { $0.uuid == PeripheralManager.SERVICE_UUID }) == nil {
             logger.warning("Couldnt restore state, since no service is available...")
             centralManager.cancelPeripheralConnection(peripheral)
             return
@@ -299,7 +293,6 @@ extension BluetoothManager {
 
         if let pumpManager = self.pumpManager {
             pumpManager.state.isConnected = false
-            pumpManager.checkBolusDone()
             pumpManager.notifyStateDidChange()
         }
 
@@ -308,8 +301,19 @@ extension BluetoothManager {
             self.peripheralManager = nil
         }
 
-        connectCompletion?(.failedToConnectToDevice)
-        connectCompletion = nil
+        if let connectCompletion = connectCompletion {
+            connectCompletion(.failedToConnectToDevice)
+            self.connectCompletion = nil
+
+        } else {
+            // Prevent reconnect spam
+            // Only try to reconnect if Authorization was successful
+            ensureConnected { error in
+                if let error = error {
+                    self.logger.warning("Failed to auto-reconnect: \(error)")
+                }
+            }
+        }
     }
 
     func centralManager(_: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {

--- a/MedtrumKit/PumpManager/MedtrumDoseProgressReporter.swift
+++ b/MedtrumKit/PumpManager/MedtrumDoseProgressReporter.swift
@@ -1,35 +1,30 @@
 import Foundation
 import LoopKit
 
-class MedtrumDoseProgressReporter: DoseProgressReporter {
-    var progress: DoseProgress {
-        DoseProgress(deliveredUnits: deliveredUnits, percentComplete: deliveredUnits / total)
+class MedtrumDoseProgressReporter: DoseProgressTimerEstimator {
+    override var progress: DoseProgress {
+        let elapsed = -dose.startDate.timeIntervalSinceNow
+        let duration = dose.estimatedEndDate.timeIntervalSince(dose.startDate)
+        let percentComplete = min(elapsed / duration, 1)
+        let delivered = pumpManager.roundToSupportedBolusVolume(units: percentComplete * dose.value)
+        return DoseProgress(deliveredUnits: delivered, percentComplete: percentComplete)
     }
 
-    private var observers = WeakSet<DoseProgressObserver>()
+    private let dose: UnfinalizedDose
+    private let pumpManager: MedtrumPumpManager
 
-    private let total: Double
-    private var deliveredUnits: Double = 0
+    public init(pumpManager: MedtrumPumpManager, dose: UnfinalizedDose, reportingQueue: DispatchQueue) {
+        self.pumpManager = pumpManager
+        self.dose = dose
 
-    public init(total: Double) {
-        self.total = total
+        super.init(reportingQueue: reportingQueue)
     }
 
-    public func addObserver(_ observer: DoseProgressObserver) {
-        observers.insert(observer)
-    }
+    override func timerParameters() -> (delay: TimeInterval, repeating: TimeInterval) {
+        let timeSinceStart = dose.startDate.timeIntervalSinceNow
+        let timeBetweenPulses = TimeInterval.seconds(2)
+        let delayUntilNextPulse = timeBetweenPulses - timeSinceStart.remainder(dividingBy: timeBetweenPulses)
 
-    public func removeObserver(_ observer: DoseProgressObserver) {
-        observers.remove(observer)
-    }
-
-    public func notify(deliveredUnits: Double) {
-        self.deliveredUnits = deliveredUnits
-
-        DispatchQueue.main.async {
-            for observer in self.observers {
-                observer.doseProgressReporterDidUpdate(self)
-            }
-        }
+        return (delay: delayUntilNextPulse, repeating: timeBetweenPulses)
     }
 }

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -25,7 +25,6 @@ public class MedtrumPumpManager: DeviceManager {
     private var doseEntry: UnfinalizedDose?
 
     let bluetooth: BluetoothManager
-
     init(state: MedtrumPumpState) {
         self.state = state
         oldState = MedtrumPumpState(rawValue: state.rawValue)
@@ -152,7 +151,7 @@ public extension MedtrumPumpManager {
     }
 
     var pumpReservoirCapacity: Double {
-        state.reservoir
+        state.model == "MD8301" ? 300 : 200
     }
 
     var lastSync: Date? {
@@ -262,7 +261,8 @@ public extension MedtrumPumpManager {
                 StateSyncer.sync(
                     syncResponse: syncResponse,
                     state: self.state,
-                    pumpManager: self
+                    pumpManager: self,
+                    duringReconnect: false
                 )
 
                 self.pumpDelegate.notify { delegate in
@@ -296,21 +296,11 @@ public extension MedtrumPumpManager {
         units * TimeInterval(minutes: 1)
     }
 
-    func startScan(_ callback: @escaping (MedtrumScanResult) -> Void) {
-        bluetooth.startScan(callback)
-    }
-
     func enactBolus(
         units: Double,
         activationType: LoopKit.BolusActivationType,
         completion: @escaping (LoopKit.PumpManagerError?) -> Void
     ) {
-        guard let insulinType = state.insulinType else {
-            log.error("Insulin type is nil...")
-            completion(.configuration(.none))
-            return
-        }
-
         guard state.bolusState == .noBolus else {
             log.error("Pump is in bolus state...")
             completion(.deviceState(MedtrumConnectError.isBolussing))
@@ -344,7 +334,7 @@ public extension MedtrumPumpManager {
                 units: units,
                 duration: duration,
                 activationType: activationType,
-                insulinType: insulinType
+                insulinType: self.state.insulinType
             )
 
             self.pumpDelegate.notify { delegate in
@@ -1055,7 +1045,7 @@ public extension MedtrumPumpManager {
         }
     }
 
-    func updateBolusProgress(delivered: Double, completed: Bool) {
+    func updateBolusProgress(delivered: Double, completed: Bool, useEstimatedEndDate: Bool) {
         if let doseReporter = doseReporter {
             doseReporter.notify(deliveredUnits: delivered)
         }
@@ -1068,7 +1058,7 @@ public extension MedtrumPumpManager {
 
         if completed {
             state.bolusState = .noBolus
-            let dose = doseEntry.toDoseEntry()
+            let dose = doseEntry.toDoseEntry(useEstimatedEndDate: useEstimatedEndDate)
             var events = [
                 NewPumpEvent.bolus(
                     dose: dose,
@@ -1116,16 +1106,16 @@ public extension MedtrumPumpManager {
         }
     }
 
-    internal func checkBolusDone() {
+    func checkBolusDone() {
         guard let doseEntry = self.doseEntry else {
-            // Disconnect was done after bolus was complete!
+            // No bolus was in progress during disconnect
             return
         }
 
-        log.warning("Bolus was not completed... \(doseEntry.deliveredUnits)U of the \(doseEntry.value)U")
+        log.warning("Bolus was not completed... \(doseEntry.deliveredUnits) U of the \(doseEntry.value) U")
 
-        // There was still a bolus running...
-        // We assume the bolus will complete since we lost the connection
+        // We assume the bolus has completed, but did not receive completed event
+        // due to being disconnected for too long
         doseEntry.deliveredUnits = doseEntry.value
         let dose = doseEntry.toDoseEntry()
         var events = [

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -297,8 +297,8 @@ public extension MedtrumPumpManager {
     }
 
     func estimatedDuration(toBolus units: Double) -> TimeInterval {
-        // 1 unit per minute
-        units * TimeInterval(minutes: 1)
+        // 1.5 unit per minute
+        units / 1.5 * TimeInterval(minutes: 1)
     }
 
     func enactBolus(

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -1117,7 +1117,7 @@ public extension MedtrumPumpManager {
         // We assume the bolus has completed, but did not receive completed event
         // due to being disconnected for too long
         doseEntry.deliveredUnits = doseEntry.value
-        let dose = doseEntry.toDoseEntry()
+        let dose = doseEntry.toDoseEntry(useEstimatedEndDate: true)
         var events = [
             NewPumpEvent.bolus(
                 dose: dose,

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -1124,7 +1124,9 @@ public extension MedtrumPumpManager {
 
         log.warning("Bolus was not completed... \(doseEntry.deliveredUnits)U of the \(doseEntry.value)U")
 
-        // There was a bolus going on, unsure if the bolus is completed...
+        // There was still a bolus running...
+        // We assume the bolus will complete since we lost the connection
+        doseEntry.deliveredUnits = doseEntry.value
         let dose = doseEntry.toDoseEntry()
         var events = [
             NewPumpEvent.bolus(

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -21,9 +21,6 @@ public class MedtrumPumpManager: DeviceManager {
         state.rawValue
     }
 
-    private var doseReporter: MedtrumDoseProgressReporter?
-    private var doseEntry: UnfinalizedDose?
-
     let bluetooth: BluetoothManager
     init(state: MedtrumPumpState) {
         self.state = state
@@ -180,7 +177,7 @@ public extension MedtrumPumpManager {
         case .canceling:
             return .canceling
         case .inProgress:
-            if let dose = doseEntry?.toDoseEntry(isMutable: true) {
+            if let dose = state.doseEntry?.toDoseEntry(isMutable: true) {
                 return .inProgress(dose)
             }
 
@@ -287,8 +284,16 @@ public extension MedtrumPumpManager {
 
     func setMustProvideBLEHeartbeat(_: Bool) {}
 
-    func createBolusProgressReporter(reportingOn _: DispatchQueue) -> (any LoopKit.DoseProgressReporter)? {
-        doseReporter
+    func createBolusProgressReporter(reportingOn: DispatchQueue) -> (any LoopKit.DoseProgressReporter)? {
+        if let doseEntry = state.doseEntry {
+            return MedtrumDoseProgressReporter(
+                pumpManager: self,
+                dose: doseEntry,
+                reportingQueue: reportingOn
+            )
+        }
+
+        return nil
     }
 
     func estimatedDuration(toBolus units: Double) -> TimeInterval {
@@ -361,8 +366,7 @@ public extension MedtrumPumpManager {
                 }
             }
 
-            self.doseEntry = doseEntry
-            self.doseReporter = MedtrumDoseProgressReporter(total: units)
+            self.state.doseEntry = doseEntry
             self.state.bolusState = .inProgress
             self.notifyStateDidChange()
 
@@ -372,8 +376,7 @@ public extension MedtrumPumpManager {
 
     private func resetBolusState() {
         state.bolusState = .noBolus
-        doseReporter = nil
-        doseEntry = nil
+        state.doseEntry = nil
         notifyStateDidChange()
     }
 
@@ -410,7 +413,7 @@ public extension MedtrumPumpManager {
             self.state.bolusState = .noBolus
             self.notifyStateDidChange()
 
-            guard let doseEntry = self.doseEntry else {
+            guard let doseEntry = self.state.doseEntry else {
                 completion(.success(nil))
                 return
             }
@@ -421,9 +424,7 @@ public extension MedtrumPumpManager {
                 events.append(tempBasalEvent)
             }
 
-            self.doseEntry = nil
-            self.doseReporter = nil
-
+            self.state.doseEntry = nil
             self.state.lastSync = Date.now
             self.notifyStateDidChange()
 
@@ -1046,68 +1047,66 @@ public extension MedtrumPumpManager {
     }
 
     func updateBolusProgress(delivered: Double, completed: Bool, useEstimatedEndDate: Bool) {
-        if let doseReporter = doseReporter {
-            doseReporter.notify(deliveredUnits: delivered)
-        }
-
-        guard let doseEntry = self.doseEntry else {
+        guard let doseEntry = state.doseEntry else {
             return
         }
 
         doseEntry.deliveredUnits = delivered
 
-        if completed {
-            state.bolusState = .noBolus
-            let dose = doseEntry.toDoseEntry(useEstimatedEndDate: useEstimatedEndDate)
-            var events = [
-                NewPumpEvent.bolus(
-                    dose: dose,
-                    units: dose.programmedUnits,
-                    date: dose.startDate
-                )
-            ]
-            if let tempBasalEvent = getTempBasalEvent() {
-                events.append(tempBasalEvent)
+        if !completed {
+            notifyStateDidChange()
+            return
+        }
+
+        state.bolusState = .noBolus
+        let dose = doseEntry.toDoseEntry(useEstimatedEndDate: useEstimatedEndDate)
+        var events = [
+            NewPumpEvent.bolus(
+                dose: dose,
+                units: dose.programmedUnits,
+                date: dose.startDate
+            )
+        ]
+        if let tempBasalEvent = getTempBasalEvent() {
+            events.append(tempBasalEvent)
+        }
+
+        state.doseEntry = nil
+        state.lastSync = Date.now
+        notifyStateDidChange()
+
+        pumpDelegate.notify { delegate in
+            guard let delegate = delegate else {
+                return
             }
 
-            self.doseEntry = nil
-            doseReporter = nil
-            state.lastSync = Date.now
-            notifyStateDidChange()
-
-            pumpDelegate.notify { delegate in
-                guard let delegate = delegate else {
-                    return
+            delegate.pumpManager(
+                self,
+                didReadReservoirValue: self.state.reservoir.rounded(toPlaces: 1),
+                at: self.state.lastSync
+            ) { result in
+                switch result {
+                case let .failure(error):
+                    self.handlePumpDelegateError(method: "didReadReservoirValue", error)
+                case .success:
+                    break
                 }
-
-                delegate.pumpManager(
-                    self,
-                    didReadReservoirValue: self.state.reservoir.rounded(toPlaces: 1),
-                    at: self.state.lastSync
-                ) { result in
-                    switch result {
-                    case let .failure(error):
-                        self.handlePumpDelegateError(method: "didReadReservoirValue", error)
-                    case .success:
-                        break
-                    }
-                }
-                delegate.pumpManager(
-                    self,
-                    hasNewPumpEvents: events,
-                    lastReconciliation: self.state.lastSync,
-                    replacePendingEvents: true
-                ) { error in
-                    if let error = error {
-                        self.handlePumpDelegateError(method: "hasNewPumpEvents", error)
-                    }
+            }
+            delegate.pumpManager(
+                self,
+                hasNewPumpEvents: events,
+                lastReconciliation: self.state.lastSync,
+                replacePendingEvents: true
+            ) { error in
+                if let error = error {
+                    self.handlePumpDelegateError(method: "hasNewPumpEvents", error)
                 }
             }
         }
     }
 
     func checkBolusDone() {
-        guard let doseEntry = self.doseEntry else {
+        guard let doseEntry = state.doseEntry else {
             // No bolus was in progress during disconnect
             return
         }
@@ -1131,7 +1130,7 @@ public extension MedtrumPumpManager {
 
         state.bolusState = .noBolus
         state.lastSync = Date.now
-        self.doseEntry = nil
+        state.doseEntry = nil
         notifyStateDidChange()
 
         pumpDelegate.notify { delegate in

--- a/MedtrumKit/PumpManager/MedtrumPumpState.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpState.swift
@@ -61,6 +61,12 @@ public class MedtrumPumpState: RawRepresentable {
             insulinType = InsulinType(rawValue: rawInsulinType)
         }
 
+        if let rawDoseEntry = rawValue["doseEntry"] as? UnfinalizedDose.RawValue {
+            doseEntry = UnfinalizedDose(rawValue: rawDoseEntry)
+        } else {
+            doseEntry = nil
+        }
+
         if let pumpStateRaw = rawValue["pumpState"] as? PatchState.RawValue {
             pumpState = PatchState(rawValue: pumpStateRaw) ?? .none
         } else {
@@ -98,6 +104,7 @@ public class MedtrumPumpState: RawRepresentable {
         lastSync = Date.distantPast
         pumpSN = Data()
         lowReservoirWarning = nil
+        doseEntry = nil
         sessionToken = Data()
         patchId = Data()
         patchActivatedAt = Date.distantPast
@@ -153,6 +160,7 @@ public class MedtrumPumpState: RawRepresentable {
         value["basalSchedule"] = basalSchedule.rawValue
         value["bolusState"] = bolusState.rawValue
         value["initialReservoir"] = initialReservoir
+        value["doseEntry"] = doseEntry?.rawValue
         value["reservoir"] = reservoir
         value["battery"] = battery
         value["basalState"] = basalState.rawValue
@@ -194,6 +202,7 @@ public class MedtrumPumpState: RawRepresentable {
     public var pumpTimeSyncedAt: Date
 
     public var pumpState: PatchState
+    public var doseEntry: UnfinalizedDose?
     public var initialReservoir: Double?
     public var reservoir: Double
     public var battery: Double

--- a/MedtrumKit/PumpManager/MedtrumPumpState.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpState.swift
@@ -289,6 +289,7 @@ public class MedtrumPumpState: RawRepresentable {
             "## MedtrumPumpState - \(Date.now)",
             "* isOnboarded: \(isOnboarded)",
             "* lastSync: \(lastSync)",
+            "* pumpState: \(pumpState.rawValue)",
             "* pumpSN: \(pumpSN.hexEncodedString())",
             "* pumpName: \(pumpName)",
             "* model: \(model)",
@@ -298,8 +299,9 @@ public class MedtrumPumpState: RawRepresentable {
             "* battery: \(battery)",
             "* pumpTime: \(pumpTime)",
             "* pumpTimeSyncedAt: \(pumpTimeSyncedAt)",
-            "* insulinType: \(insulinType ?? .afrezza)",
+            "* insulinType: \(String(describing: insulinType))",
             "* reservoirLevel: \(reservoir)",
+            "* lowReservoirWarning: \(String(describing: lowReservoirWarning))",
             "* bolusState: \(bolusState.rawValue)"
         ].joined(separator: "\n")
     }

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -154,7 +154,7 @@ extension PeripheralManager {
                 return
             }
 
-            parseStateUpdate(syncResponse)
+            parseStateUpdate(syncResponse, duringReconnect: true)
             await subscribe()
         }
     }
@@ -178,7 +178,7 @@ extension PeripheralManager {
         }
     }
 
-    private func parseStateUpdate(_ syncResponse: SynchronizePacketResponse) {
+    private func parseStateUpdate(_ syncResponse: SynchronizePacketResponse, duringReconnect: Bool) {
         // TEMP
         do {
             log.info("State update: \(String(data: try JSONEncoder().encode(syncResponse), encoding: .utf8) ?? "")")
@@ -189,7 +189,8 @@ extension PeripheralManager {
         StateSyncer.sync(
             syncResponse: syncResponse,
             state: pumpManager.state,
-            pumpManager: pumpManager
+            pumpManager: pumpManager,
+            duringReconnect: duringReconnect
         )
     }
 }
@@ -277,7 +278,7 @@ extension PeripheralManager: CBPeripheralDelegate {
                 var packet = NotificationPacket()
                 packet.decode(data)
 
-                self.parseStateUpdate(packet.parseResponse())
+                self.parseStateUpdate(packet.parseResponse(), duringReconnect: false)
                 return
             }
 

--- a/MedtrumKit/PumpManager/StateSyncer.swift
+++ b/MedtrumKit/PumpManager/StateSyncer.swift
@@ -4,7 +4,8 @@ enum StateSyncer {
     static func sync(
         syncResponse: SynchronizePacketResponse,
         state: MedtrumPumpState,
-        pumpManager: MedtrumPumpManager
+        pumpManager: MedtrumPumpManager,
+        duringReconnect: Bool
     ) {
         StateSyncer.updatePumpState(syncResponse: syncResponse, state: state)
 
@@ -73,8 +74,14 @@ enum StateSyncer {
         }
 
         if let bolusProgress = syncResponse.bolus {
-            pumpManager.updateBolusProgress(delivered: bolusProgress.delivered, completed: bolusProgress.completed)
+            pumpManager.updateBolusProgress(
+                delivered: bolusProgress.delivered,
+                completed: bolusProgress.completed,
+                useEstimatedEndDate: duringReconnect
+            )
             pumpManager.state.bolusState = bolusProgress.completed ? .noBolus : .inProgress
+        } else if duringReconnect {
+            pumpManager.checkBolusDone()
         }
 
         pumpManager.notifyStateDidChange()

--- a/MedtrumKit/PumpManager/StateSyncer.swift
+++ b/MedtrumKit/PumpManager/StateSyncer.swift
@@ -66,7 +66,8 @@ enum StateSyncer {
 
         if let startTime = syncResponse.startTime {
             state.patchActivatedAt = startTime
-            state.patchExpiresAt = state.patchActivatedAt.addingTimeInterval(.days(3)).addingTimeInterval(.hours(8))
+            state.patchGracePeriodFrom = state.patchActivatedAt.addingTimeInterval(.hours(72))
+            state.patchExpiresAt = state.patchActivatedAt.addingTimeInterval(.hours(80))
         }
 
         if let storage = syncResponse.storage {

--- a/MedtrumKitUI/ViewModels/Onboarding/PatchPrimingViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Onboarding/PatchPrimingViewModel.swift
@@ -59,7 +59,9 @@ class PatchPrimingViewModel: ObservableObject {
                 }
 
                 if pumpManager.state.pumpState.rawValue >= PatchState.primed.rawValue {
-                    self.nextStep()
+                    DispatchQueue.main.async {
+                        self.nextStep()
+                    }
                     return
                 }
 

--- a/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
+++ b/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
@@ -443,7 +443,7 @@ struct MedtrumKitSettings: View {
                     Text(LocalizedString("Expires in:", comment: "Text shown while patch is active"))
                         .foregroundStyle(.secondary)
                     Spacer()
-                    if let days = viewModel.patchLifecycleDays {
+                    if let days = viewModel.patchLifecycleDays, days > 0 {
                         timeComponent(
                             value: days,
                             units: days == 1 ?


### PR DESCRIPTION
closes #92 

Currently, medtrumkit will not update the delivered units correctly if a BLE disconnect happens.
This PR will change MedtrumKit to assume the bolus will complete eventually and update the delivered units accordingly.

Not too sure if this has always been an issue

Tagging @marionbarker 