### PR TITLE
fix: update heartbeat handling

### DIFF
--- a/Common/CBUUID.swift
+++ b/Common/CBUUID.swift
@@ -1,0 +1,7 @@
+import CoreBluetooth
+
+extension CBUUID {
+    static let SERVICE_UUID = CBUUID(string: "669A9001-0008-968F-E311-6050405558B3")
+    static let READ_UUID = CBUUID(string: "669a9120-0008-968f-e311-6050405558b3")
+    static let WRITE_UUID = CBUUID(string: "669a9101-0008-968f-e311-6050405558b3")
+}

--- a/MedtrumKit.xcodeproj/project.pbxproj
+++ b/MedtrumKit.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		3E5060222D70FDA100376609 /* SetTimeZonePacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5060212D70FDA000376609 /* SetTimeZonePacket.swift */; };
 		3E5060242D70FED500376609 /* SynchronizePacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5060232D70FED500376609 /* SynchronizePacket.swift */; };
 		3E5060262D71035900376609 /* SubscribePacket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5060252D71035900376609 /* SubscribePacket.swift */; };
+		3E5FB2AC2FA62CAC00E6151C /* CBUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5FB2AB2FA62CA900E6151C /* CBUUID.swift */; };
 		3E6A00EE2DA03FE00085E6A4 /* PatchDeactivationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E6A00ED2DA03FE00085E6A4 /* PatchDeactivationView.swift */; };
 		3E6A00F02DA0421A0085E6A4 /* DeactivatePatchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E6A00EF2DA042140085E6A4 /* DeactivatePatchViewModel.swift */; };
 		3E6A00F22DA0428E0085E6A4 /* MedtrumDeactivatePatchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E6A00F12DA0428E0085E6A4 /* MedtrumDeactivatePatchResult.swift */; };
@@ -196,6 +197,7 @@
 		3E5060212D70FDA000376609 /* SetTimeZonePacket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetTimeZonePacket.swift; sourceTree = "<group>"; };
 		3E5060232D70FED500376609 /* SynchronizePacket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizePacket.swift; sourceTree = "<group>"; };
 		3E5060252D71035900376609 /* SubscribePacket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscribePacket.swift; sourceTree = "<group>"; };
+		3E5FB2AB2FA62CA900E6151C /* CBUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBUUID.swift; sourceTree = "<group>"; };
 		3E6A00ED2DA03FE00085E6A4 /* PatchDeactivationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchDeactivationView.swift; sourceTree = "<group>"; };
 		3E6A00EF2DA042140085E6A4 /* DeactivatePatchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeactivatePatchViewModel.swift; sourceTree = "<group>"; };
 		3E6A00F12DA0428E0085E6A4 /* MedtrumDeactivatePatchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MedtrumDeactivatePatchResult.swift; sourceTree = "<group>"; };
@@ -451,6 +453,7 @@
 		3E767CE32D67AF2B004B1971 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				3E5FB2AB2FA62CA900E6151C /* CBUUID.swift */,
 				3E0406DF2EB7872C0013E362 /* Binding.swift */,
 				3E15A47D2DA2B723007F7D3C /* NibLoadable.swift */,
 				3E15A47B2DA2B718007F7D3C /* IdentifiableClass.swift */,
@@ -714,8 +717,9 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				en,
 				ar,
-				zh-Hans,
+				"zh-Hans",
 				cs,
 				da,
 				nl,
@@ -729,7 +733,7 @@
 				ja,
 				nb,
 				pl,
-				pt-BR,
+				"pt-BR",
 				ro,
 				ru,
 				sk,
@@ -737,7 +741,7 @@
 				sv,
 				tr,
 				uk,
-				vi
+				vi,
 			);
 			mainGroup = B7D3A8C62C148CC4002EE003;
 			productRefGroup = B7D3A8D12C148CC4002EE003 /* Products */;
@@ -842,6 +846,7 @@
 				DD334CAC2F941CC90082A5B5 /* PatchLifetimeFormatting+Helper.swift in Sources */,
 				3EA87C3D2DAC2F9C00E897ED /* NotificationPacket.swift in Sources */,
 				3E26BE0B2D9069A600E595B0 /* MedtrumKitSettings.swift in Sources */,
+				3E5FB2AC2FA62CAC00E6151C /* CBUUID.swift in Sources */,
 				3EA69F052D95E605002EEF9F /* InsulinTypeSelector.swift in Sources */,
 				3E15324A2D6FA0080020F015 /* Data.swift in Sources */,
 				3E9D8B102D88A5F200008AF2 /* UnfinalizedDose.swift in Sources */,

--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -100,7 +100,7 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
             return
         }
 
-        let connectedDevices = manager.retrieveConnectedPeripherals(withServices: [PeripheralManager.SERVICE_UUID])
+        let connectedDevices = manager.retrieveConnectedPeripherals(withServices: [CBUUID.SERVICE_UUID])
         if let peripheral = connectedDevices.first(where: { $0.name == "MT" }) {
             // Phone is already connected, but the app is not
             startTimeout(seconds: .seconds(15))
@@ -275,7 +275,7 @@ extension BluetoothManager {
 
         self.peripheral = peripheral
         peripheralManager = PeripheralManager(peripheral, self, pumpManager, completion)
-        peripheral.discoverServices([PeripheralManager.SERVICE_UUID])
+        peripheral.discoverServices([CBUUID.SERVICE_UUID])
     }
 
     func centralManager(_ centralManager: CBCentralManager, willRestoreState dict: [String: Any]) {
@@ -285,7 +285,7 @@ extension BluetoothManager {
             return
         }
 
-        if peripheral.services?.first(where: { $0.uuid == PeripheralManager.SERVICE_UUID }) == nil {
+        if peripheral.services?.first(where: { $0.uuid == CBUUID.SERVICE_UUID }) == nil {
             logger.warning("Couldnt restore state, since no service is available...")
             centralManager.cancelPeripheralConnection(peripheral)
             return

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -185,7 +185,7 @@ public extension MedtrumPumpManager {
 
     func ensureCurrentPumpData(completion: ((Date?) -> Void)?) {
         guard let activatedAt = state.patchActivatedAt,
-              Date.now.timeIntervalSince(state.lastSync) > .minutes(4) ||
+              Date.now.timeIntervalSince(state.lastSync) > .minutes(2.5) ||
               Date.now.timeIntervalSince(activatedAt) < .minutes(4)
         else {
             log.warning("Skipping status update -> data is fresh or not active: \(Date.now.timeIntervalSince(state.lastSync)) sec")

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -188,7 +188,7 @@ public extension MedtrumPumpManager {
               Date.now.timeIntervalSince(state.lastSync) > .minutes(4) ||
               Date.now.timeIntervalSince(activatedAt) < .minutes(4)
         else {
-            log.warning("Skipping status update -> data is fresh: \(Date.now.timeIntervalSince(state.lastSync)) sec")
+            log.warning("Skipping status update -> data is fresh or not active: \(Date.now.timeIntervalSince(state.lastSync)) sec")
             completion?(nil)
             return
         }
@@ -230,7 +230,7 @@ public extension MedtrumPumpManager {
             }
 
             let syncResult = await self.bluetooth.write(SynchronizePacket())
-            await StateSyncer.timeSync(pumpManager: self)
+            await StateSyncer.fetchPatchTime(pumpManager: self)
 
             switch syncResult {
             case let .failure(error):
@@ -251,30 +251,13 @@ public extension MedtrumPumpManager {
                     self.log.warning("State update: Failed to encode JSON")
                 }
 
-                self.state.lastSync = Date.now
-                self.notifyStateDidChange()
-
                 StateSyncer.sync(
                     syncResponse: syncResponse,
                     state: self.state,
                     pumpManager: self,
-                    duringReconnect: false
+                    duringReconnect: false,
+                    fullSync: true
                 )
-
-                self.pumpDelegate.notify { delegate in
-                    delegate?.pumpManager(
-                        self,
-                        didReadReservoirValue: self.state.reservoir.rounded(toPlaces: 1),
-                        at: self.state.lastSync
-                    ) { result in
-                        switch result {
-                        case let .failure(error):
-                            self.handlePumpDelegateError(method: "didReadReservoirValue", error)
-                        case .success:
-                            break
-                        }
-                    }
-                }
 
                 completion?(Date.now)
             }
@@ -1073,6 +1056,23 @@ public extension MedtrumPumpManager {
         }
 
         return events
+    }
+    
+    func emitReservoirLevel() {
+        self.pumpDelegate.notify { delegate in
+            delegate?.pumpManager(
+                self,
+                didReadReservoirValue: self.state.reservoir.rounded(toPlaces: 1),
+                at: self.state.lastSync
+            ) { result in
+                switch result {
+                case let .failure(error):
+                    self.handlePumpDelegateError(method: "didReadReservoirValue", error)
+                case .success:
+                    break
+                }
+            }
+        }
     }
     
     private func emitPumpEvents(_ events: [NewPumpEvent], replacePendingEvents: Bool = true) {

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -9,10 +9,7 @@ class PeripheralManager: NSObject {
     private let pumpManager: MedtrumPumpManager
     private var completion: ((MedtrumConnectError?) -> Void)?
 
-    public static let SERVICE_UUID = CBUUID(string: "669A9001-0008-968F-E311-6050405558B3")
-    private static let READ_UUID = CBUUID(string: "669a9120-0008-968f-e311-6050405558b3")
     private var readCharacteristic: CBCharacteristic?
-    private static let WRITE_UUID = CBUUID(string: "669a9101-0008-968f-e311-6050405558b3")
     private var writeCharacteristic: CBCharacteristic?
 
     private var writeSequence: UInt8 = 0
@@ -154,7 +151,7 @@ extension PeripheralManager {
                 return
             }
 
-            parseStateUpdate(syncResponse, duringReconnect: true)
+            parseStateUpdate(syncResponse, duringReconnect: true, fullSync: true)
             await subscribe()
         }
     }
@@ -178,7 +175,7 @@ extension PeripheralManager {
         }
     }
 
-    private func parseStateUpdate(_ syncResponse: SynchronizePacketResponse, duringReconnect: Bool) {
+    private func parseStateUpdate(_ syncResponse: SynchronizePacketResponse, duringReconnect: Bool, fullSync: Bool) {
         // TEMP
         do {
             log.info("State update: \(String(data: try JSONEncoder().encode(syncResponse), encoding: .utf8) ?? "")")
@@ -190,7 +187,8 @@ extension PeripheralManager {
             syncResponse: syncResponse,
             state: pumpManager.state,
             pumpManager: pumpManager,
-            duringReconnect: duringReconnect
+            duringReconnect: duringReconnect,
+            fullSync: fullSync
         )
     }
 }
@@ -203,7 +201,7 @@ extension PeripheralManager: CBPeripheralDelegate {
             return
         }
 
-        let service = peripheral.services?.first(where: { $0.uuid == PeripheralManager.SERVICE_UUID })
+        let service = peripheral.services?.first(where: { $0.uuid == CBUUID.SERVICE_UUID })
         guard let service = service else {
             let localizedError = "No Medtrum service found - " +
                 (peripheral.services?.map(\.uuid.uuidString).joined(separator: ", ") ?? "No services discovered")
@@ -212,7 +210,7 @@ extension PeripheralManager: CBPeripheralDelegate {
             return
         }
 
-        peripheral.discoverCharacteristics([PeripheralManager.READ_UUID, PeripheralManager.WRITE_UUID], for: service)
+        peripheral.discoverCharacteristics([CBUUID.READ_UUID, CBUUID.WRITE_UUID], for: service)
     }
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
@@ -222,9 +220,8 @@ extension PeripheralManager: CBPeripheralDelegate {
             return
         }
 
-        let service = peripheral.services!.first(where: { $0.uuid == PeripheralManager.SERVICE_UUID })!
-        readCharacteristic = service.characteristics?.first(where: { $0.uuid == PeripheralManager.READ_UUID })
-        writeCharacteristic = service.characteristics?.first(where: { $0.uuid == PeripheralManager.WRITE_UUID })
+        readCharacteristic = service.characteristics?.first(where: { $0.uuid == CBUUID.READ_UUID })
+        writeCharacteristic = service.characteristics?.first(where: { $0.uuid == CBUUID.WRITE_UUID })
 
         guard readCharacteristic != nil, writeCharacteristic != nil else {
             let localizedError = "Failed to discover read, write or config characteristic - " +
@@ -260,25 +257,19 @@ extension PeripheralManager: CBPeripheralDelegate {
             return
         }
 
-        guard var data = characteristic.value else {
+        guard let data = characteristic.value else {
             log.warning("No data in didUpdateValueFor - characteristic: \(characteristic.uuid.uuidString)")
             return
         }
 
         queue.async {
-            if characteristic.uuid.uuidString.lowercased() == PeripheralManager.READ_UUID.uuidString.lowercased() {
+            if characteristic.uuid.uuidString.lowercased() == CBUUID.READ_UUID.uuidString.lowercased() {
                 guard data[1] != 0x00 else {
                     // Ignore all ping messages from patch pomp
                     return
                 }
 
-                self.log.debug("READ -> Got data: \(data.hexEncodedString())")
-                data.append(0x00) // Little CRC hack. The notification lacks the CRC value, thus add an empty value there
-
-                var packet = NotificationPacket()
-                packet.decode(data)
-
-                self.parseStateUpdate(packet.parseResponse(), duringReconnect: false)
+                self.handleHeartbeat(data: data)
                 return
             }
 
@@ -336,6 +327,48 @@ extension PeripheralManager: CBPeripheralDelegate {
             writeCallback.finish()
             self.writeQueue = nil
             self.currentPacket = nil
+        }
+    }
+    
+    private func handleHeartbeat(data: Data) {
+        var data = data
+
+        self.log.debug("READ -> Got data: \(data.hexEncodedString())")
+        data.append(0x00) // Little CRC hack. The notification lacks the CRC value, thus add an empty value there
+
+        var packet = NotificationPacket()
+        packet.decode(data)
+
+        guard Date.now.timeIntervalSince(self.pumpManager.state.lastSync) > .minutes(2.5) else {
+            self.parseStateUpdate(packet.parseResponse(), duringReconnect: false, fullSync: false)
+            self.log.debug("State too fresh, skipping full sync...")
+            return
+        }
+        
+        guard self.pumpManager.state.bolusState == .noBolus else {
+            self.parseStateUpdate(packet.parseResponse(), duringReconnect: false, fullSync: false)
+            self.log.warning("Skipping sync, pump is currently bolusing")
+            return
+        }
+
+        // Do full sync (only every 3min)
+        Task {
+            let response = await self.writePacket(SynchronizePacket())
+            await StateSyncer.fetchPatchTime(pumpManager: self.pumpManager)
+
+            switch response {
+            case let .failure(error):
+                self.log.error("Failed to get synchronize: \(error.localizedDescription)")
+                return
+
+            case let .success(data):
+                guard let syncResponse = data as? SynchronizePacketResponse else {
+                    self.log.error("Failed to Synchronize packet: invalid response")
+                    return
+                }
+
+                self.parseStateUpdate(syncResponse, duringReconnect: false, fullSync: true)
+            }
         }
     }
 }

--- a/MedtrumKit/PumpManager/StateSyncer.swift
+++ b/MedtrumKit/PumpManager/StateSyncer.swift
@@ -5,8 +5,13 @@ enum StateSyncer {
         syncResponse: SynchronizePacketResponse,
         state: MedtrumPumpState,
         pumpManager: MedtrumPumpManager,
-        duringReconnect: Bool
+        duringReconnect: Bool,
+        fullSync: Bool
     ) {
+        if fullSync {
+            pumpManager.state.lastSync = Date.now
+        }
+
         StateSyncer.updatePumpState(syncResponse: syncResponse, state: state)
 
         if let reservoir = syncResponse.reservoir {
@@ -21,6 +26,11 @@ enum StateSyncer {
             state.reservoir = reservoir
             if state.initialReservoir == nil {
                 state.initialReservoir = state.reservoir
+            }
+            
+            if fullSync {
+                // to prevent spaming the OSAID app with reservoir updates
+                pumpManager.emitReservoirLevel()
             }
         }
 
@@ -83,7 +93,7 @@ enum StateSyncer {
         pumpManager.notifyStateDidChange()
     }
 
-    public static func timeSync(pumpManager: MedtrumPumpManager) async {
+    public static func fetchPatchTime(pumpManager: MedtrumPumpManager) async {
         let logger = MedtrumLogger(category: "TimeSync")
         let timeData = await pumpManager.bluetooth.write(GetTimePacket())
 
@@ -123,7 +133,7 @@ enum StateSyncer {
             logger.error("Failed to sync timezone: \(error.errorDescription)")
             return
         default:
-            await StateSyncer.timeSync(pumpManager: pumpManager)
+            await StateSyncer.fetchPatchTime(pumpManager: pumpManager)
         }
     }
 


### PR DESCRIPTION
### Introduction
This PR updates the way MedtrumKit deals with the heartbeat of the patch.

Quoted from #106:
```
- Use the heartbeat messages from the patch to trigger a full sync every 3min
- Update the heartbeat handling to not process the short state update, but to wait until the state is >3min, then send a full-sync message to the patch
- Use the full-sync response to keep the state up-to-date

If the state is >12min old, then the patch is truly not connected, making the error message valid again
```

### Test setup
Tested using the Unified Pump Manager & Nightscout CGM.
Used both Trio (0.7.0) & Loop (feat/add_all_managers).

Both Trio & Loop stayed green after 20 minutes running in the foreground

### Misc
Tagging @dnzxy & @marionbarker 
Closes #106 