### PR TITLE
fix: rework unfinalized dose

### DIFF
--- a/Common/NewPumpEvent.swift
+++ b/Common/NewPumpEvent.swift
@@ -2,16 +2,17 @@ import Foundation
 import LoopKit
 
 public extension NewPumpEvent {
+    private static let dateFormatter = ISO8601DateFormatter()
+
     static func bolus(dose: DoseEntry, units: Double, date: Date = Date.now) -> NewPumpEvent {
-        let dateFormatter = ISO8601DateFormatter()
-        return NewPumpEvent(
+        NewPumpEvent(
             date: date,
             dose: dose,
             raw: "\(DoseType.bolus.rawValue) \(units) \(dateFormatter.string(from: date))".data(using: .utf8) ?? Data([]),
             title: String(localized: "Bolus", comment: "Pump Event title for UnfinalizedDose with doseType of .bolus")
         )
     }
-    
+
     static func bolus(unfinalizedDose: UnfinalizedDose) -> NewPumpEvent {
         let dose = unfinalizedDose.toDoseEntry(isMutable: true)
         return NewPumpEvent.bolus(
@@ -22,8 +23,7 @@ public extension NewPumpEvent {
     }
 
     static func tempBasal(dose: DoseEntry, date: Date = Date.now) -> NewPumpEvent {
-        let dateFormatter = ISO8601DateFormatter()
-        return NewPumpEvent(
+        NewPumpEvent(
             date: date,
             dose: dose,
             raw: "\(DoseType.tempBasal.rawValue) \(dose.programmedUnits) \(dateFormatter.string(from: date))"
@@ -33,8 +33,7 @@ public extension NewPumpEvent {
     }
 
     static func basal(dose: DoseEntry, date: Date = Date.now) -> NewPumpEvent {
-        let dateFormatter = ISO8601DateFormatter()
-        return NewPumpEvent(
+        NewPumpEvent(
             date: date,
             dose: dose,
             raw: "\(DoseType.basal.rawValue) \(dateFormatter.string(from: date))".data(using: .utf8) ?? Data([]),
@@ -43,8 +42,7 @@ public extension NewPumpEvent {
     }
 
     static func resume(dose: DoseEntry, date: Date = Date.now) -> NewPumpEvent {
-        let dateFormatter = ISO8601DateFormatter()
-        return NewPumpEvent(
+        NewPumpEvent(
             date: date,
             dose: dose,
             raw: "\(DoseType.resume.rawValue) \(dateFormatter.string(from: date))".data(using: .utf8) ?? Data([]),
@@ -53,8 +51,7 @@ public extension NewPumpEvent {
     }
 
     static func suspend(dose: DoseEntry, date: Date = Date.now) -> NewPumpEvent {
-        let dateFormatter = ISO8601DateFormatter()
-        return NewPumpEvent(
+        NewPumpEvent(
             date: date,
             dose: dose,
             raw: "\(DoseType.suspend.rawValue) \(dateFormatter.string(from: date))".data(using: .utf8) ?? Data([]),
@@ -63,8 +60,7 @@ public extension NewPumpEvent {
     }
 
     static func replacedPump(date: Date = Date.now) -> NewPumpEvent {
-        let dateFormatter = ISO8601DateFormatter()
-        return NewPumpEvent(
+        NewPumpEvent(
             date: Date.now,
             dose: nil,
             raw: "PATCH_REPLACE \(dateFormatter.string(from: date))".data(using: .utf8) ?? Data([]),

--- a/Common/UnfinalizedDose.swift
+++ b/Common/UnfinalizedDose.swift
@@ -25,7 +25,7 @@ public class UnfinalizedDose {
         self.insulinType = insulinType
         automatic = activationType.isAutomatic
     }
-    
+
     public init(basalRate: Double, insulinType: InsulinType?, startDate: Date = Date.now) {
         type = .basal
         value = basalRate
@@ -34,7 +34,7 @@ public class UnfinalizedDose {
         self.insulinType = insulinType
         automatic = false
     }
-    
+
     public init(tempRate: Double, duration: TimeInterval, insulinType: InsulinType?) {
         type = .tempBasal
         value = tempRate
@@ -43,7 +43,7 @@ public class UnfinalizedDose {
         estimatedEndDate = startDate.addingTimeInterval(duration)
         automatic = true
     }
-    
+
     public init(suspendStartTime: Date) {
         type = .suspend
         value = 0
@@ -52,7 +52,7 @@ public class UnfinalizedDose {
         automatic = false // OSAID does not use suspend function
         insulinType = nil
     }
-    
+
     public init(resumeStartTime: Date, insulinType: InsulinType?) {
         type = .resume
         value = 0
@@ -136,19 +136,19 @@ public class UnfinalizedDose {
                 // The endDate of a bolus cannot be in the future...
                 endDate = Date.now
             }
-            
+
             return DoseEntry(
                 type: .bolus,
                 startDate: startDate,
                 endDate: endDate,
                 value: value.rounded(toPlaces: 2),
                 unit: .units,
-                deliveredUnits: isMutable ? nil : self.deliveredUnits.rounded(toPlaces: 2),
+                deliveredUnits: isMutable ? nil : deliveredUnits.rounded(toPlaces: 2),
                 insulinType: insulinType,
                 automatic: automatic,
                 isMutable: isMutable
             )
-            
+
         case .basal:
             return DoseEntry(
                 type: .basal,
@@ -157,14 +157,9 @@ public class UnfinalizedDose {
                 unit: .unitsPerHour,
                 insulinType: insulinType
             )
-            
+
         case .tempBasal:
-            var actualEndDate = isMutable ? estimatedEndDate : endDate
-            if !isMutable, estimatedEndDate < endDate {
-                // Temp basal already expired, update endDate & add normal basal event
-                actualEndDate = estimatedEndDate
-            }
-            
+            let actualEndDate = isMutable ? estimatedEndDate : endDate
             let duration = actualEndDate.timeIntervalSince(startDate)
             return DoseEntry(
                 type: .tempBasal,
@@ -177,28 +172,26 @@ public class UnfinalizedDose {
                 automatic: automatic,
                 isMutable: isMutable
             )
-            
+
         case .suspend:
             return DoseEntry(
                 suspendDate: startDate,
-                automatic: automatic,
-                isMutable: isMutable
+                automatic: automatic
             )
-            
+
         case .resume:
             return DoseEntry(
                 resumeDate: startDate,
                 insulinType: insulinType,
-                automatic: automatic,
-                isMutable: isMutable
+                automatic: automatic
             )
         }
     }
-    
+
     private func roundBasalRate(_ rate: Double) -> Double {
         MedtrumPumpManager.onboardingSupportedBasalRates.last(where: { $0 <= rate }) ?? 0
     }
-    
+
     public static func defaultBasalDose(basalSchedule: BasalSchedule, insulineType: InsulinType?) -> UnfinalizedDose {
         let now = Date()
         let startOfDay = Calendar.current.startOfDay(for: now)

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -282,12 +282,6 @@ public extension MedtrumPumpManager {
             return
         }
 
-        guard state.basalState != .suspended else {
-            log.error("Pump is suspended...")
-            completion(.deviceState(MedtrumConnectError.isSuspended))
-            return
-        }
-
         let duration = estimatedDuration(toBolus: units)
         log.info("Enact bolus - \(units)U, \(duration)sec")
 

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -163,24 +163,9 @@ public extension MedtrumPumpManager {
             device: device(state),
             pumpBatteryChargeRemaining: nil, // Patch pumps do not need to report back battery status
             basalDeliveryState: state.basalDeliveryState,
-            bolusState: bolusState(state.bolusState),
+            bolusState: state.bolusDeliveryState,
             insulinType: state.insulinType
         )
-    }
-
-    private func bolusState(_ bolusState: BolusState) -> PumpManagerStatus.BolusState {
-        switch bolusState {
-        case .noBolus:
-            return .noBolus
-        case .canceling:
-            return .canceling
-        case .inProgress:
-            if let dose = state.bolusDose?.toDoseEntry(isMutable: true) {
-                return .inProgress(dose)
-            }
-
-            return .noBolus
-        }
     }
 
     func ensureCurrentPumpData(completion: ((Date?) -> Void)?) {
@@ -188,7 +173,10 @@ public extension MedtrumPumpManager {
               Date.now.timeIntervalSince(state.lastSync) > .minutes(2.5) ||
               Date.now.timeIntervalSince(activatedAt) < .minutes(4)
         else {
-            log.warning("Skipping status update -> data is fresh or not active: \(Date.now.timeIntervalSince(state.lastSync)) sec")
+            log
+                .warning(
+                    "Skipping status update -> data is fresh or not active: \(Date.now.timeIntervalSince(state.lastSync)) sec"
+                )
             completion?(nil)
             return
         }
@@ -294,6 +282,12 @@ public extension MedtrumPumpManager {
             return
         }
 
+        guard state.basalState != .suspended else {
+            log.error("Pump is suspended...")
+            completion(.deviceState(MedtrumConnectError.isSuspended))
+            return
+        }
+
         let duration = estimatedDuration(toBolus: units)
         log.info("Enact bolus - \(units)U, \(duration)sec")
 
@@ -392,7 +386,7 @@ public extension MedtrumPumpManager {
             self.state.bolusDose = nil
             self.state.lastSync = Date.now
             self.notifyStateDidChange()
-            
+
             self.emitPumpEvents(events)
 
             completion(.success(nil))
@@ -447,20 +441,20 @@ public extension MedtrumPumpManager {
                         insulinType: self.state.insulinType,
                         startDate: now
                     )
-                    
+
                     events.append(
                         NewPumpEvent.basal(
                             dose: basalDose.toDoseEntry(),
                             date: now
                         )
                     )
-                    
+
                     self.state.basalDose = basalDose
                 }
 
                 self.state.lastSync = Date.now
                 self.notifyStateDidChange()
-                
+
                 self.emitPumpEvents(events)
 
                 completion(nil)
@@ -494,7 +488,7 @@ public extension MedtrumPumpManager {
             self.state.basalDose = tempBasalDose
             self.state.lastSync = Date.now
             self.notifyStateDidChange()
-            
+
             self.emitPumpEvents(events)
 
             completion(nil)
@@ -524,17 +518,16 @@ public extension MedtrumPumpManager {
                 return
             }
 
-            
             let start = Date.now
             let basalDose = UnfinalizedDose(suspendStartTime: start)
-            
+
             var events = self.getActivePumpEvents(endDate: start)
             events.append(NewPumpEvent.suspend(dose: basalDose.toDoseEntry()))
 
             self.state.basalDose = basalDose
             self.state.lastSync = Date.now
             self.notifyStateDidChange()
-            
+
             self.emitPumpEvents(events)
 
             self.log.info("Delivery suspended for \(duration.minutes) min!")
@@ -567,14 +560,14 @@ public extension MedtrumPumpManager {
                 resumeStartTime: Date.now,
                 insulinType: self.state.insulinType
             )
-            
+
             var events = self.getActivePumpEvents()
             events.append(NewPumpEvent.resume(dose: resumeDose.toDoseEntry(), date: resumeDose.startDate))
 
             self.state.basalDose = resumeDose
             self.state.lastSync = Date.now
             self.notifyStateDidChange()
-            
+
             self.emitPumpEvents(events)
 
             completion(nil)
@@ -611,7 +604,7 @@ public extension MedtrumPumpManager {
             self.state.basalSchedule = schedule
             self.state.lastSync = Date.now
             self.notifyStateDidChange()
-            
+
             self.log.info("Basal schedule sync complete!")
 
             completion(.success(basalSchedule))
@@ -771,7 +764,7 @@ public extension MedtrumPumpManager {
 
             let suspendStart = Date.now
             let suspendDose = UnfinalizedDose(suspendStartTime: suspendStart)
-            
+
             var events = self.getActivePumpEvents(endDate: suspendStart)
             events.append(NewPumpEvent.suspend(dose: suspendDose.toDoseEntry()))
 
@@ -793,7 +786,7 @@ public extension MedtrumPumpManager {
 
     func forceDeactivatePatch() {
         let suspendDose = UnfinalizedDose(suspendStartTime: Date.now)
-        
+
         var events = getActivePumpEvents(endDate: Date.now)
         events.append(NewPumpEvent.suspend(dose: suspendDose.toDoseEntry()))
 
@@ -1038,38 +1031,18 @@ public extension MedtrumPumpManager {
         guard state.basalDose.type == .tempBasal else {
             return []
         }
-        
+
         let basalEntry = state.basalDose.toDoseEntry(isMutable: endDate == nil, endDate: endDate ?? Date.now)
-        var events = [
+        return [
             NewPumpEvent.tempBasal(
                 dose: basalEntry,
                 date: basalEntry.startDate
             )
         ]
-        
-        if !basalEntry.isMutable, basalEntry.endDate == state.basalDose.estimatedEndDate {
-            // Temp basal expired, append normal basal event
-            state.basalDose = UnfinalizedDose(
-                basalRate: state.currentBaseBasalRate,
-                insulinType: state.insulinType,
-                startDate: state.basalDose.estimatedEndDate
-            )
-            
-            events.append(
-                NewPumpEvent.basal(
-                    dose: state.basalDose.toDoseEntry(),
-                    date: state.basalDose.startDate
-                )
-            )
-            
-            notifyStateDidChange()
-        }
-
-        return events
     }
-    
+
     func emitReservoirLevel() {
-        self.pumpDelegate.notify { delegate in
+        pumpDelegate.notify { delegate in
             delegate?.pumpManager(
                 self,
                 didReadReservoirValue: self.state.reservoir.rounded(toPlaces: 1),
@@ -1084,8 +1057,8 @@ public extension MedtrumPumpManager {
             }
         }
     }
-    
-    private func emitPumpEvents(_ events: [NewPumpEvent], replacePendingEvents: Bool = true) {
+
+    func emitPumpEvents(_ events: [NewPumpEvent], replacePendingEvents: Bool = true) {
         pumpDelegate.notify { delegate in
             guard let delegate = delegate else {
                 self.log.warning("No pump delegate, not notifying...")

--- a/MedtrumKit/PumpManager/MedtrumPumpState.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpState.swift
@@ -275,7 +275,7 @@ public class MedtrumPumpState: RawRepresentable {
         case .suspend:
             return .suspended(basalDose.startDate)
         case .tempBasal:
-            return .tempBasal(basalDose.toDoseEntry())
+            return .tempBasal(basalDose.toDoseEntry(isMutable: true))
         }
     }
 

--- a/MedtrumKit/PumpManager/MedtrumPumpState.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpState.swift
@@ -115,15 +115,16 @@ public class MedtrumPumpState: RawRepresentable {
         } else {
             alarmSetting = .BeepOnly
         }
-        
+
         if let rawDoseEntry = rawValue["bolusDose"] as? UnfinalizedDose.RawValue {
             bolusDose = UnfinalizedDose(rawValue: rawDoseEntry)
         } else {
             bolusDose = nil
         }
-        
+
         if let rawDoseEntry = rawValue["basalDose"] as? UnfinalizedDose.RawValue {
-            basalDose = UnfinalizedDose(rawValue: rawDoseEntry) ?? UnfinalizedDose.defaultBasalDose(basalSchedule: basalSchedule, insulineType: insulinType)
+            basalDose = UnfinalizedDose(rawValue: rawDoseEntry) ?? UnfinalizedDose
+                .defaultBasalDose(basalSchedule: basalSchedule, insulineType: insulinType)
         } else {
             basalDose = UnfinalizedDose.defaultBasalDose(basalSchedule: basalSchedule, insulineType: insulinType)
         }
@@ -160,7 +161,7 @@ public class MedtrumPumpState: RawRepresentable {
         } else {
             basalSchedule = BasalSchedule(entries: [LoopKit.RepeatingScheduleValue(startTime: 0, value: 0)])
         }
-        
+
         basalDose = UnfinalizedDose.defaultBasalDose(basalSchedule: basalSchedule, insulineType: insulinType)
     }
 
@@ -258,7 +259,7 @@ public class MedtrumPumpState: RawRepresentable {
 
     public var bolusState: BolusState
     public var bolusDose: UnfinalizedDose?
-    
+
     // basalState is the basalState from the patch itself
     // Preventing acting on an out-dated basalDose
     public var basalState: BasalState
@@ -267,14 +268,29 @@ public class MedtrumPumpState: RawRepresentable {
 
     public var basalDeliveryState: PumpManagerStatus.BasalDeliveryState {
         switch basalDose.type {
-        case .resume,
-             .basal,
-             .bolus:
+        case .basal,
+             .bolus,
+             .resume:
             return .active(basalDose.startDate)
         case .suspend:
             return .suspended(basalDose.startDate)
         case .tempBasal:
             return .tempBasal(basalDose.toDoseEntry())
+        }
+    }
+
+    var bolusDeliveryState: PumpManagerStatus.BolusState {
+        switch bolusState {
+        case .noBolus:
+            return .noBolus
+        case .canceling:
+            return .canceling
+        case .inProgress:
+            if let dose = bolusDose?.toDoseEntry(isMutable: true) {
+                return .inProgress(dose)
+            }
+
+            return .noBolus
         }
     }
 

--- a/MedtrumKit/PumpManager/Models/MedtrumConnectResult.swift
+++ b/MedtrumKit/PumpManager/Models/MedtrumConnectResult.swift
@@ -18,7 +18,10 @@ public enum MedtrumConnectError: LocalizedError {
         case let .failedToCompleteAuthorizationFlow(localizedErr):
             return localizedErr
         case .failedToConnectToDevice:
-            return "Failed to connect to device -> Timeout reached..."
+            return String(
+                localized: "Failed to connect to patch -> Timeout reached",
+                comment: "MedtrumError patch failedToConnectToDevice"
+            )
         case .failedToFindDevice:
             return "Failed to find device"
         case .isBolussing:

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -329,25 +329,25 @@ extension PeripheralManager: CBPeripheralDelegate {
             self.currentPacket = nil
         }
     }
-    
+
     private func handleHeartbeat(data: Data) {
         var data = data
 
-        self.log.debug("READ -> Got data: \(data.hexEncodedString())")
+        log.debug("READ -> Got data: \(data.hexEncodedString())")
         data.append(0x00) // Little CRC hack. The notification lacks the CRC value, thus add an empty value there
 
         var packet = NotificationPacket()
         packet.decode(data)
 
-        guard Date.now.timeIntervalSince(self.pumpManager.state.lastSync) > .minutes(2.5) else {
-            self.parseStateUpdate(packet.parseResponse(), duringReconnect: false, fullSync: false)
-            self.log.debug("State too fresh, skipping full sync...")
+        guard Date.now.timeIntervalSince(pumpManager.state.lastSync) > .minutes(2.5) else {
+            parseStateUpdate(packet.parseResponse(), duringReconnect: false, fullSync: false)
+            log.debug("State too fresh, skipping full sync...")
             return
         }
-        
-        guard self.pumpManager.state.bolusState == .noBolus else {
-            self.parseStateUpdate(packet.parseResponse(), duringReconnect: false, fullSync: false)
-            self.log.warning("Skipping sync, pump is currently bolusing")
+
+        guard pumpManager.state.bolusState == .noBolus else {
+            parseStateUpdate(packet.parseResponse(), duringReconnect: false, fullSync: false)
+            log.warning("Skipping sync, pump is currently bolusing")
             return
         }
 

--- a/MedtrumKit/PumpManager/StateSyncer.swift
+++ b/MedtrumKit/PumpManager/StateSyncer.swift
@@ -27,7 +27,7 @@ enum StateSyncer {
             if state.initialReservoir == nil {
                 state.initialReservoir = state.reservoir
             }
-            
+
             if fullSync {
                 // to prevent spaming the OSAID app with reservoir updates
                 pumpManager.emitReservoirLevel()
@@ -56,9 +56,55 @@ enum StateSyncer {
                  .SUSPEND_MORE_THAN_MAX_PER_DAY,
                  .SUSPEND_MORE_THAN_MAX_PER_HOUR,
                  .SUSPEND_PREDICT_LOW_GLUCOSE:
+                if state.basalDose.type == .basal || state.basalDose.type == .resume || state.basalDose.type == .tempBasal {
+                    // Patch unexpectedly suspended itself
+                    let eventTime = Date.now
+                    let dose = state.basalDose.toDoseEntry(isMutable: false, endDate: eventTime)
+                    state.basalDose = UnfinalizedDose(suspendStartTime: eventTime)
+                    let basalDose = state.basalDose.toDoseEntry()
+
+                    var events: [NewPumpEvent] = [NewPumpEvent.basal(dose: basalDose, date: basalDose.startDate)]
+                    if dose.type == .tempBasal {
+                        // Record finalized temp basal, resume/basal is already finalized
+                        events.append(NewPumpEvent.tempBasal(dose: dose, date: dose.startDate))
+                    }
+
+                    pumpManager.emitPumpEvents(events)
+                    pumpManager.notifyStateDidChange()
+                }
+
                 state.basalState = .suspended
 
             default:
+                if state.basalDose.type == .suspend || state.basalDose.type == .tempBasal {
+                    // unfinalized dose is finalized!
+                    let eventTime = Date.now
+                    let dose = state.basalDose.toDoseEntry(isMutable: false, endDate: eventTime)
+                    state.basalDose = dose.type == .tempBasal ?
+                        UnfinalizedDose(
+                            basalRate: state.currentBaseBasalRate,
+                            insulinType: state.insulinType
+                        ) :
+                        UnfinalizedDose(
+                            resumeStartTime: eventTime,
+                            insulinType: state.insulinType
+                        )
+
+                    let basalDose = state.basalDose.toDoseEntry(isMutable: true)
+                    var events: [NewPumpEvent] = [
+                        basalDose.type == .resume ?
+                            NewPumpEvent.resume(dose: basalDose, date: basalDose.startDate) :
+                            NewPumpEvent.basal(dose: basalDose, date: basalDose.startDate)
+                    ]
+                    if dose.type == .tempBasal {
+                        // Record finalized temp basal, suspend is already finalized
+                        events.append(NewPumpEvent.tempBasal(dose: dose, date: dose.startDate))
+                    }
+
+                    pumpManager.emitPumpEvents(events)
+                    pumpManager.notifyStateDidChange()
+                }
+
                 state.basalState = .active
             }
         }
@@ -88,6 +134,8 @@ enum StateSyncer {
             pumpManager.state.bolusState = bolusProgress.completed ? .noBolus : .inProgress
         } else if duringReconnect {
             pumpManager.checkBolusDone()
+        } else {
+            pumpManager.state.bolusState = .noBolus
         }
 
         pumpManager.notifyStateDidChange()

--- a/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
@@ -366,7 +366,7 @@ extension MedtrumKitSettingsViewModel {
         pumpTimeSyncedAt = state.pumpTimeSyncedAt
         reservoirLevel = patchState != .reservoirEmpty ? state.reservoir : 0
         basalType = state.basalDose.type
-        basalRate = state.basalDose.value
+        basalRate = basalType == .tempBasal ? state.basalDose.value : state.currentBaseBasalRate
         lastSync = state.lastSync
         patchActivatedAt = state.patchActivatedAt
         patchGracePeriodFrom = state.patchGracePeriodFrom

--- a/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
+++ b/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
@@ -515,9 +515,9 @@ struct MedtrumKitSettings: View {
 
             switch viewModel.basalType {
             case .basal,
-                 .tempBasal,
+                 .bolus,
                  .resume,
-                 .bolus:
+                 .tempBasal:
                 HStack(alignment: .center) {
                     HStack(alignment: .lastTextBaseline, spacing: 3) {
                         Text(viewModel.basalRateFormatter.string(from: viewModel.basalRate as NSNumber) ?? "")
@@ -677,9 +677,9 @@ struct MedtrumKitSettings: View {
 
     var deliverySectionTitle: String {
         switch viewModel.basalType {
-        case .resume,
-             .basal,
-             .bolus:
+        case .basal,
+             .bolus,
+             .resume:
             return String(localized: "Scheduled Basal", comment: "Title of insulin delivery section")
         case .tempBasal:
             return String(localized: "Temp Basal", comment: "Pump Event title for UnfinalizedDose with doseType of .tempBasal")


### PR DESCRIPTION
This PR originally tried to fix the suspend unfinalized dose (which missed the duration part), but now reworks the unfinalized dose flow.

The new flow uses the Patch's heartbeat in order to detect if dose is finalized
This has the benefit of not needing a loop cycle to keep the history up-to-date.

This PR is able to detect the following changes:
- Temp basal/Suspended -> scheduled basal (expired/finalized dose)
- Temp basal/Scheduled basal -> Suspended (for hourly/daily max insulin limit)

Test setup:
- NightScout Remote CGM
- Unified Pump Simulator (SHA: https://github.com/bastiaanv/unified-pump-simulator/commit/0d243a277311e7eb8a8adf30e01a05b7d6e75a48)
- Trio v0.7.0

Also ran the SwiftFormat of Trio (sorry for the unrelated changes)
Closes #127 