### PR TITLE
Centralize navigation titles in coordinator

### DIFF
--- a/MedtrumKitUI/ViewController/MedtrumKitUICoordinator.swift
+++ b/MedtrumKitUI/ViewController/MedtrumKitUICoordinator.swift
@@ -104,7 +104,10 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
     private func viewControllerForScreen(_ screen: MedtrumUIScreen) -> UIViewController {
         switch screen {
         case .welcomeScreen:
-            return hostingController(rootView: OnboardingWelcomeView(nextStep: { self.navigateTo(.insulinTypeScreen) }))
+            return hostingController(
+                rootView: OnboardingWelcomeView(nextStep: { self.navigateTo(.insulinTypeScreen) }),
+                title: String(localized: "Welcome", comment: "welcome header")
+            )
 
         case .insulinTypeScreen:
             let nextStep: (InsulinType) -> Void = { insulinType in
@@ -117,12 +120,15 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
 
                 self.navigateTo(.patchSettingsScreen)
             }
-            return hostingController(rootView: InsulinTypeSelector(
-                initialValue: pumpManager?.state.insulinType ?? allowedInsulinTypes[0],
-                supportedInsulinTypes: allowedInsulinTypes,
-                showSave: pumpManager?.isOnboarded ?? false,
-                didConfirm: nextStep
-            ))
+            return hostingController(
+                rootView: InsulinTypeSelector(
+                    initialValue: pumpManager?.state.insulinType ?? allowedInsulinTypes[0],
+                    supportedInsulinTypes: allowedInsulinTypes,
+                    showSave: pumpManager?.isOnboarded ?? false,
+                    didConfirm: nextStep
+                ),
+                title: String(localized: "Select insulin type", comment: "Title for insulin type")
+            )
 
         case .patchSettingsScreen:
             let nextStep = {
@@ -143,15 +149,21 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
                 dirtyCheck = !pumpManager.state.patchId.isEmpty
             }
 
-            return hostingController(rootView: PatchSettingsView(
-                viewModel: viewModel,
-                doDirtyCheck: dirtyCheck
-            ))
+            return hostingController(
+                rootView: PatchSettingsView(
+                    viewModel: viewModel,
+                    doDirtyCheck: dirtyCheck
+                ),
+                title: String(localized: "Patch Settings", comment: "Text for patch settings view")
+            )
 
         case .deactivatePatchScreen:
             let nextStep = { self.resetNavigationTo([.settingsScreen, .pumpBaseSettingsScreen]) }
             let viewModel = DeactivatePatchViewModel(pumpManager, nextStep)
-            return hostingController(rootView: PatchDeactivationView(viewModel: viewModel))
+            return hostingController(
+                rootView: PatchDeactivationView(viewModel: viewModel),
+                title: String(localized: "Deactivate Patch", comment: "deactive patch")
+            )
 
         case .pumpBaseSettingsScreen:
             let nextStep = {
@@ -171,7 +183,10 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
 
             let viewModel = PumpBaseSettingsViewModel(pumpManager, nextStep)
 
-            return hostingController(rootView: PumpBaseSettingsView(viewModel: viewModel))
+            return hostingController(
+                rootView: PumpBaseSettingsView(viewModel: viewModel),
+                title: String(localized: "Pump base settings", comment: "Pump base settings header")
+            )
 
         case .patchPrimingScreen:
             let viewModel = PatchPrimingViewModel(
@@ -182,7 +197,8 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
             )
             return hostingController(
                 rootView: PatchPrimingView(viewModel: viewModel)
-                    .onAppear { UIApplication.shared.isIdleTimerDisabled = true }
+                    .onAppear { UIApplication.shared.isIdleTimerDisabled = true },
+                title: String(localized: "Patch Priming", comment: "Priming header")
             )
 
         case .patchActivationScreen:
@@ -193,7 +209,8 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
             )
             return hostingController(
                 rootView: PatchActivationView(viewModel: viewModel)
-                    .onAppear { UIApplication.shared.isIdleTimerDisabled = true }
+                    .onAppear { UIApplication.shared.isIdleTimerDisabled = true },
+                title: String(localized: "Patch Activation", comment: "Patch activation header")
             )
 
         case .settingsScreen:
@@ -230,20 +247,36 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
                 pumpRemoval,
                 toActivatePatch
             )
-            return hostingController(rootView: MedtrumKitSettings(viewModel: viewModel))
+            return hostingController(
+                rootView: MedtrumKitSettings(viewModel: viewModel),
+                title: pumpManager?.state.pumpName ?? "Medtrum Nano"
+            )
         case .patchDetailsScreen:
             let viewModel = PatchDetailsViewModel(pumpManager: pumpManager)
-            return hostingController(rootView: PatchDetailsView(viewModel: viewModel))
+            return hostingController(
+                rootView: PatchDetailsView(viewModel: viewModel),
+                title: String(localized: "Patch Details", comment: "header patch details")
+            )
         case .patchPreviousDetailsScreen:
             let viewModel = PreviousPatchDetailsViewModel(pumpManager: pumpManager)
-            return hostingController(rootView: PreviousPatchDetailsView(viewModel: viewModel))
+            return hostingController(
+                rootView: PreviousPatchDetailsView(viewModel: viewModel),
+                title: String(localized: "Previous Patch Details", comment: "header patch details")
+            )
         }
     }
 
-    private func hostingController<Content: View>(rootView: Content) -> DismissibleHostingController<some View> {
+    private func hostingController<Content: View>(
+        rootView: Content,
+        title: String? = nil,
+        largeTitleDisplayMode: UINavigationItem.LargeTitleDisplayMode = .automatic
+    ) -> DismissibleHostingController<some View> {
         let rootView = rootView
             .environment(\.appName, Bundle.main.bundleDisplayName)
-        return DismissibleHostingController(content: rootView, colorPalette: colorPalette)
+        let hostedView = DismissibleHostingController(content: rootView, colorPalette: colorPalette)
+        hostedView.navigationItem.title = title
+        hostedView.navigationItem.largeTitleDisplayMode = largeTitleDisplayMode
+        return hostedView
     }
 
     override func viewDidDisappear(_: Bool) {

--- a/MedtrumKitUI/Views/Onboarding/OnboardingWelcomeView.swift
+++ b/MedtrumKitUI/Views/Onboarding/OnboardingWelcomeView.swift
@@ -27,7 +27,6 @@ struct OnboardingWelcomeView: View {
         }
         .listStyle(InsetGroupedListStyle())
         .edgesIgnoringSafeArea(.bottom)
-        .navigationTitle(String(localized: "Welcome", comment: "welcome header"))
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button(String(localized: "Cancel", comment: "Cancel button title"), action: {

--- a/MedtrumKitUI/Views/Onboarding/PatchActivationView.swift
+++ b/MedtrumKitUI/Views/Onboarding/PatchActivationView.swift
@@ -74,7 +74,6 @@ struct PatchActivationView: View {
         }
         .listStyle(InsetGroupedListStyle())
         .edgesIgnoringSafeArea(.bottom)
-        .navigationTitle(String(localized: "Patch Activation", comment: "Patch activation header"))
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button(String(localized: "Cancel", comment: "Cancel button title"), action: {

--- a/MedtrumKitUI/Views/Onboarding/PatchDeactivationView.swift
+++ b/MedtrumKitUI/Views/Onboarding/PatchDeactivationView.swift
@@ -49,6 +49,5 @@ struct PatchDeactivationView: View {
         }
         .listStyle(InsetGroupedListStyle())
         .edgesIgnoringSafeArea(.bottom)
-        .navigationTitle(String(localized: "Deactivate Patch", comment: "deactive patch"))
     }
 }

--- a/MedtrumKitUI/Views/Onboarding/PatchPrimingView.swift
+++ b/MedtrumKitUI/Views/Onboarding/PatchPrimingView.swift
@@ -100,7 +100,6 @@ struct PatchPrimingView: View {
         .listStyle(InsetGroupedListStyle())
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarBackButtonHidden(viewModel.isPriming)
-        .navigationTitle(String(localized: "Patch Priming", comment: "Priming header"))
     }
 
     @ViewBuilder func supportImage(_ imageName: String) -> some View {

--- a/MedtrumKitUI/Views/Onboarding/PumpBaseSettingsView.swift
+++ b/MedtrumKitUI/Views/Onboarding/PumpBaseSettingsView.swift
@@ -44,6 +44,5 @@ struct PumpBaseSettingsView: View {
         }
         .listStyle(InsetGroupedListStyle())
         .edgesIgnoringSafeArea(.bottom)
-        .navigationTitle(String(localized: "Pump base settings", comment: "Pump base settings header"))
     }
 }

--- a/MedtrumKitUI/Views/Settings/InsulinTypeSelector.swift
+++ b/MedtrumKitUI/Views/Settings/InsulinTypeSelector.swift
@@ -60,6 +60,5 @@ struct InsulinTypeSelector: View {
         }
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarHidden(false)
-        .navigationTitle(String(localized: "Select insulin type", comment: "Title for insulin type"))
     }
 }

--- a/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
+++ b/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
@@ -480,7 +480,6 @@ struct MedtrumKitSettings: View {
         }
         .listStyle(InsetGroupedListStyle())
         .navigationBarItems(trailing: doneButton)
-        .navigationBarTitle(viewModel.pumpName)
     }
 
     var reservoirStatus: some View {

--- a/MedtrumKitUI/Views/Settings/PatchDetailsView.swift
+++ b/MedtrumKitUI/Views/Settings/PatchDetailsView.swift
@@ -48,7 +48,6 @@ struct PatchDetailsView: View {
             }
         }
         .listStyle(InsetGroupedListStyle())
-        .navigationBarTitle(String(localized: "Patch Details", comment: "header patch details"))
     }
 
     @ViewBuilder func sectionItem(title: Text, value: String) -> some View {

--- a/MedtrumKitUI/Views/Settings/PatchSettingsView.swift
+++ b/MedtrumKitUI/Views/Settings/PatchSettingsView.swift
@@ -220,7 +220,6 @@ struct PatchSettingsView: View {
             .padding([.bottom, .horizontal])
         }
         .edgesIgnoringSafeArea(.bottom)
-        .navigationBarTitle(String(localized: "Patch Settings", comment: "Text for patch settings view"))
     }
 
     @ViewBuilder func sectionItem(

--- a/MedtrumKitUI/Views/Settings/PreviousPatchDetailsView.swift
+++ b/MedtrumKitUI/Views/Settings/PreviousPatchDetailsView.swift
@@ -47,7 +47,6 @@ struct PreviousPatchDetailsView: View {
             }
         }
         .listStyle(InsetGroupedListStyle())
-        .navigationBarTitle(String(localized: "Previous Patch Details", comment: "header patch details"))
     }
 
     @ViewBuilder func sectionItem(title: Text, value: String) -> some View {


### PR DESCRIPTION
This addresses the issue of navigation titles not displaying with iOS 26