### PR TITLE
Recover session token via backup/restore (responseCode 7/32)

### DIFF
--- a/MedtrumKit/Packets/Enums/PatchState.swift
+++ b/MedtrumKit/Packets/Enums/PatchState.swift
@@ -76,3 +76,19 @@ public enum PatchState: UInt8, Codable {
         }
     }
 }
+
+/// Classifies patch states for session-token lifecycle decisions.
+enum SessionTokenPolicy {
+    /// True when the patch has permanently ended and must be replaced (occlusion,
+    /// expired, reservoir empty, fault, battery out, stopped, ...). When this is
+    /// reached we back up and clear the active token so the next patch starts with
+    /// a fresh one.
+    ///
+    /// IMPORTANT: the boundary is `>= occlusion` (96), NOT `> active` (32).
+    /// States 33-70 (active_alt, the suspends and paused) are also `> 32` but are
+    /// recoverable and must KEEP their token; and transient activation states like
+    /// `ejecting`/`ejected` (5/6) are below 32 and must also keep their token.
+    static func isTerminal(_ state: PatchState) -> Bool {
+        state.rawValue >= PatchState.occlusion.rawValue
+    }
+}

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -622,10 +622,9 @@ public extension MedtrumPumpManager {
         }
 
         if state.sessionToken.isEmpty {
-            log.debug("Refreshing session token...")
-
-            // Patch has been disabled and thus a new session token is needed
-            state.sessionToken = Crypto.genSessionToken()
+            // No token yet (fresh base, or it was cleared when the previous patch
+            // ended). Mint one; the patch binds it during the prime/activate auth.
+            setSessionToken(Crypto.genSessionToken(), reason: "prime: token was empty")
             notifyStateDidChange()
         }
 
@@ -760,7 +759,7 @@ public extension MedtrumPumpManager {
 
             self.state.patchId = Data()
             self.state.pumpState = .none
-            self.state.sessionToken = Data()
+            self.backupAndClearSessionToken(reason: "deactivate")
             self.state.lastSync = Date.now
             self.state.basalDose = suspendDose
             self.notifyStateDidChange()
@@ -793,13 +792,76 @@ public extension MedtrumPumpManager {
 
         state.patchId = Data()
         state.pumpState = .none
-        state.sessionToken = Data()
+        backupAndClearSessionToken(reason: "force deactivate")
         state.lastSync = Date.now
         state.basalDose = suspendDose
         notifyStateDidChange()
 
         emitPumpEvents(events)
     }
+
+    #if MEDTRUM_DEBUG
+    // MARK: - Debug helpers (MEDTRUM_DEBUG builds only; not for public release)
+    //
+    // Tooling to experiment with the session token on an already-active patch.
+    // NOTE: a patch that rejects auth with responseCode 7 is bound to a token we
+    // cannot reproduce, and the firmware offers no way to re-bind a token to an
+    // active patch - so these are unlikely to recover it. They are kept for
+    // local debugging only.
+
+    var debugSessionTokenHex: String { state.sessionToken.hexEncodedString() }
+    var debugBackupSessionTokenHex: String { state.backupSessionToken.hexEncodedString() }
+    var debugPumpSNHex: String { state.pumpSN.hexEncodedString() }
+
+    /// Replace the stored session token with a fresh random value.
+    func debugRegenerateSessionToken() {
+        setSessionToken(Crypto.genSessionToken(), reason: "debug: regenerate")
+        notifyStateDidChange()
+    }
+
+    /// Replace the stored session token with a specific 4-byte value (hex string).
+    @discardableResult
+    func debugSetSessionToken(hex: String) -> Bool {
+        let cleaned = hex.replacingOccurrences(of: " ", with: "")
+        guard !cleaned.isEmpty, let data = Data(hex: cleaned), data.count == 4 else {
+            log.error("DEBUG: invalid session token hex (need 4 bytes / 8 hex chars)")
+            return false
+        }
+
+        setSessionToken(data, reason: "debug: set hex")
+        notifyStateDidChange()
+        return true
+    }
+
+    /// Clear the stored session token (next activation will mint a new one).
+    func debugClearSessionToken() {
+        setSessionToken(Data(), reason: "debug: clear")
+        notifyStateDidChange()
+    }
+
+    /// Promote the backup token to the active one (manual restore).
+    func debugRestoreBackupSessionToken() {
+        if restoreBackupSessionToken(reason: "debug: restore backup") {
+            notifyStateDidChange()
+        } else {
+            log.error("DEBUG: no usable backup session token to restore")
+        }
+    }
+
+    /// Drop the current connection and immediately re-run the auth flow using the
+    /// currently stored session token.
+    func debugForceReconnect() {
+        log.debug("DEBUG: forcing reconnect to re-attempt authorization")
+        bluetooth.disconnect(force: true)
+        bluetooth.ensureConnected { error in
+            if let error = error {
+                self.log.error("DEBUG: reconnect failed: \(error)")
+            } else {
+                self.log.debug("DEBUG: reconnect + authorization succeeded")
+            }
+        }
+    }
+    #endif
 
     func clearAlert(alertType: AlertType, completion: @escaping (Bool) -> Void) {
         log.info("Clearing alert - alertType: \(alertType.rawValue)")
@@ -866,6 +928,43 @@ public extension MedtrumPumpManager {
 
     func removeStatusObserver(_ observer: PumpManagerStatusObserver) {
         statusObservers.removeElement(observer)
+    }
+
+    // MARK: - Session token
+
+    /// Single funnel for every write to the active session token, so all
+    /// manipulations are auditable (logged under MEDTRUM_DEBUG).
+    func setSessionToken(_ newValue: Data, reason: String) {
+        #if MEDTRUM_DEBUG
+        let from = state.sessionToken.isEmpty ? "(empty)" : state.sessionToken.hexEncodedString()
+        let to = newValue.isEmpty ? "(empty)" : newValue.hexEncodedString()
+        log.info("sessionToken [\(reason)]: \(from) -> \(to)")
+        #endif
+        state.sessionToken = newValue
+    }
+
+    /// Back up the current token (if any) and clear the active one. Used when the
+    /// patch permanently ends, so the next patch starts with a fresh token while
+    /// the old one stays recoverable via `restoreBackupSessionToken` if the patch
+    /// later rejects auth (responseCode 7), or when the active token is empty.
+    func backupAndClearSessionToken(reason: String) {
+        guard !state.sessionToken.isEmpty else { return }
+        #if MEDTRUM_DEBUG
+        log.info("sessionToken backup [\(reason)]: \(state.sessionToken.hexEncodedString()) -> backup")
+        #endif
+        state.backupSessionToken = state.sessionToken
+        setSessionToken(Data(), reason: reason)
+    }
+
+    /// Promote the backup token to the active one (used on an auth rejection).
+    /// Returns false if there is no usable, different backup to try.
+    @discardableResult
+    func restoreBackupSessionToken(reason: String) -> Bool {
+        guard !state.backupSessionToken.isEmpty, state.backupSessionToken != state.sessionToken else {
+            return false
+        }
+        setSessionToken(state.backupSessionToken, reason: reason)
+        return true
     }
 
     func notifyStateDidChange() {

--- a/MedtrumKit/PumpManager/MedtrumPumpState.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpState.swift
@@ -54,6 +54,7 @@ public class MedtrumPumpState: RawRepresentable {
         pumpSN = rawValue["pumpSN"] as? Data ?? Data()
         lowReservoirWarning = rawValue["lowReservoirWarning"] as? Double
         sessionToken = rawValue["sessionToken"] as? Data ?? Data()
+        backupSessionToken = rawValue["backupSessionToken"] as? Data ?? Data()
         patchId = rawValue["patchId"] as? Data ?? Data()
         patchActivatedAt = rawValue["patchActivatedAt"] as? Date ?? nil
         deviceType = rawValue["deviceType"] as? UInt8 ?? 0
@@ -137,6 +138,7 @@ public class MedtrumPumpState: RawRepresentable {
         lowReservoirWarning = nil
         bolusDose = nil
         sessionToken = Data()
+        backupSessionToken = Data()
         patchId = Data()
         patchActivatedAt = nil
         deviceType = 0
@@ -174,6 +176,7 @@ public class MedtrumPumpState: RawRepresentable {
         value["lowReservoirWarning"] = lowReservoirWarning
         value["pumpSN"] = pumpSN
         value["sessionToken"] = sessionToken
+        value["backupSessionToken"] = backupSessionToken
         value["patchId"] = patchId
         value["patchActivatedAt"] = patchActivatedAt
         value["patchGracePeriodFrom"] = patchGracePeriodFrom
@@ -214,6 +217,10 @@ public class MedtrumPumpState: RawRepresentable {
 
     // Patch specific data
     public var sessionToken: Data
+    /// Last-known-good auth token, kept so it can be restored if the active token
+    /// is cleared/replaced and the patch then rejects auth (responseCode 7), or
+    /// when the active token is found empty.
+    public var backupSessionToken: Data
     public var patchId: Data
     public var patchActivatedAt: Date?
     public var patchGracePeriodFrom: Date? {

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -84,14 +84,49 @@ class PeripheralManager: NSObject {
 }
 
 extension PeripheralManager {
+    /// Auth was rejected because of a wrong session token. Only `7` is
+    /// documented ("invalid authorization"). We intentionally do NOT act on other
+    /// codes (e.g. 32) - their meaning is undocumented and 32 collides with the
+    /// value of the active patch state, so treating it as a token error would be a
+    /// guess. The empty-token case is handled separately, before sending auth.
+    private static func isAuthTokenRejection(_ error: MedtrumWriteError) -> Bool {
+        if case let .invalidResponse(code) = error {
+            return code == 7
+        }
+        return false
+    }
+
     // Connect step 1
-    private func doAuthorize() {
+    private func doAuthorize(triedBackup: Bool = false) {
+        // An empty active token can never authorize. If we have a backup (e.g. the
+        // token was cleared when the previous patch ended), use it rather than
+        // sending an empty request - this avoids depending on whatever code the
+        // patch returns for an empty token.
+        if !triedBackup, pumpManager.state.sessionToken.isEmpty,
+           pumpManager.restoreBackupSessionToken(reason: "auth: active token empty, using backup")
+        {
+            pumpManager.notifyStateDidChange()
+        }
+
         let authData = writePacket(
             AuthorizePacket(pumpSN: pumpManager.state.pumpSN, sessionToken: pumpManager.state.sessionToken)
         )
 
         switch authData {
         case let .failure(error):
+            // Wrong token (code 7). The patch still responded, so the connection is
+            // up: try the backup token once on the same connection before giving up.
+            // This recovers patches whose active token was cleared/replaced (e.g.
+            // force-deactivate) while the patch is still bound to the previous one.
+            if !triedBackup, Self.isAuthTokenRejection(error),
+               pumpManager.restoreBackupSessionToken(reason: "auth rejected: \(error.errorDescription)")
+            {
+                pumpManager.notifyStateDidChange()
+                log.info("Authorization rejected (\(error.errorDescription)); retrying with backup session token")
+                doAuthorize(triedBackup: true)
+                return
+            }
+
             log.error("Failed to complete authorization flow: \(error.localizedDescription)")
             bluetoothManager.disconnect()
             completion?(.failedToCompleteAuthorizationFlow(localizedError: error.localizedDescription))

--- a/MedtrumKit/PumpManager/StateSyncer.swift
+++ b/MedtrumKit/PumpManager/StateSyncer.swift
@@ -16,6 +16,16 @@ enum StateSyncer {
 
         StateSyncer.updatePumpState(syncResponse: syncResponse, state: state)
 
+        // When the patch permanently ends (occlusion / expired / reservoir empty /
+        // fault / battery out / stopped - i.e. >= occlusion), back up and clear the
+        // session token so the next patch starts with a fresh one. The old token
+        // stays recoverable via restore-on-auth-failure. NOTE: this must NOT fire
+        // on suspends/paused (64-70) or transient activation states (ejecting/
+        // ejected) - those keep their token.
+        if SessionTokenPolicy.isTerminal(syncResponse.state) {
+            pumpManager.backupAndClearSessionToken(reason: "patch terminal: \(syncResponse.state.description)")
+        }
+
         if let reservoir = syncResponse.reservoir {
             if let lowReservoirWarning = state.lowReservoirWarning,
                state.reservoir > lowReservoirWarning,

--- a/MedtrumKitTests/PumpManager/BasalScheduleTests.swift
+++ b/MedtrumKitTests/PumpManager/BasalScheduleTests.swift
@@ -31,3 +31,43 @@ final class BasalScheduleTests: XCTestCase {
         XCTAssert(actual.elementsEqual(expected))
     }
 }
+
+final class SessionTokenPolicyTests: XCTestCase {
+    // Genuinely terminal (must-replace) states back up + clear the token.
+    func testTerminalStatesAreTerminal() {
+        XCTAssertTrue(SessionTokenPolicy.isTerminal(.occlusion))
+        XCTAssertTrue(SessionTokenPolicy.isTerminal(.expired))
+        XCTAssertTrue(SessionTokenPolicy.isTerminal(.reservoirEmpty))
+        XCTAssertTrue(SessionTokenPolicy.isTerminal(.patchFault))
+        XCTAssertTrue(SessionTokenPolicy.isTerminal(.patchFaultd2))
+        XCTAssertTrue(SessionTokenPolicy.isTerminal(.baseFault))
+        XCTAssertTrue(SessionTokenPolicy.isTerminal(.batteryOut))
+        XCTAssertTrue(SessionTokenPolicy.isTerminal(.stopped))
+    }
+
+    // Active and the recoverable suspend/paused states are NOT terminal and MUST
+    // keep their token - they are >32 but below `occlusion`.
+    func testActiveAndSuspendStatesAreNotTerminal() {
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.active))
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.active_alt))
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.lowBgSuspended))
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.autoSuspended))
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.hourlyMaxSuspended))
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.dailyMaxSuspended))
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.suspended))
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.paused))
+    }
+
+    // Transient activation/needle states (ejecting/ejected) and pre-active states
+    // are NOT terminal - clearing the token here was the regression that wiped a
+    // live patch's token mid-activation.
+    func testTransientAndPreActiveStatesAreNotTerminal() {
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.none))
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.idle))
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.filled))
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.priming))
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.primed))
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.ejecting))
+        XCTAssertFalse(SessionTokenPolicy.isTerminal(.ejected))
+    }
+}

--- a/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
@@ -48,6 +48,11 @@ class MedtrumKitSettingsViewModel: PatchLifetimeFormatting, ObservableObject, Pu
     @Published var hasPreviousPatch = false
     @Published var isClearingAlert = false
 
+    #if MEDTRUM_DEBUG
+    @Published var debugSessionToken: String = ""
+    @Published var debugBackupToken: String = ""
+    #endif
+
     public var pumpName: String {
         pumpManager?.state.pumpName ?? "Medtrum Nano"
     }
@@ -397,6 +402,42 @@ extension MedtrumKitSettingsViewModel {
             self.insulinType = insulinType
         }
     }
+
+    #if MEDTRUM_DEBUG
+    var debugPumpSN: String { pumpManager?.debugPumpSNHex ?? "" }
+    var debugPatchState: String { pumpManager?.state.pumpState.description ?? "-" }
+
+    func debugRefreshToken() {
+        debugSessionToken = pumpManager?.debugSessionTokenHex ?? ""
+        debugBackupToken = pumpManager?.debugBackupSessionTokenHex ?? ""
+    }
+
+    func debugRegenerateToken() {
+        pumpManager?.debugRegenerateSessionToken()
+        debugRefreshToken()
+    }
+
+    func debugClearToken() {
+        pumpManager?.debugClearSessionToken()
+        debugRefreshToken()
+    }
+
+    @discardableResult
+    func debugSetToken(_ hex: String) -> Bool {
+        let ok = pumpManager?.debugSetSessionToken(hex: hex) ?? false
+        debugRefreshToken()
+        return ok
+    }
+
+    func debugRestoreBackup() {
+        pumpManager?.debugRestoreBackupSessionToken()
+        debugRefreshToken()
+    }
+
+    func debugForceReconnect() {
+        pumpManager?.debugForceReconnect()
+    }
+    #endif
 
     private func getLifecycleState(state: MedtrumPumpState) -> PatchLifecycleState {
         if patchLifecycleProgress < 1 {

--- a/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
+++ b/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
@@ -6,6 +6,10 @@ struct MedtrumKitSettings: View {
     @State private var isSharePresented: Bool = false
     @ObservedObject var viewModel: MedtrumKitSettingsViewModel
 
+    #if MEDTRUM_DEBUG
+    @State private var debugTokenInput: String = ""
+    #endif
+
     @Environment(\.dismissAction) private var dismiss
     @Environment(\.insulinTintColor) var insulinTintColor
     @Environment(\.guidanceColors) private var guidanceColors
@@ -477,10 +481,75 @@ struct MedtrumKitSettings: View {
                     removePumpManagerActionSheet(deleteAction: viewModel.pumpRemovalAction)
                 }
             }
+
+            #if MEDTRUM_DEBUG
+            debugSection
+            #endif
         }
         .listStyle(InsetGroupedListStyle())
         .navigationBarItems(trailing: doneButton)
     }
+
+    #if MEDTRUM_DEBUG
+    @ViewBuilder var debugSection: some View {
+        Section {
+            HStack {
+                Text(verbatim: "Pump SN")
+                Spacer()
+                Text(viewModel.debugPumpSN).foregroundColor(.secondary).font(.system(.body, design: .monospaced))
+            }
+            HStack {
+                Text(verbatim: "Session token")
+                Spacer()
+                Text(viewModel.debugSessionToken.isEmpty ? "(empty)" : viewModel.debugSessionToken)
+                    .foregroundColor(.secondary)
+                    .font(.system(.body, design: .monospaced))
+            }
+            HStack {
+                Text(verbatim: "Backup token")
+                Spacer()
+                Text(viewModel.debugBackupToken.isEmpty ? "(empty)" : viewModel.debugBackupToken)
+                    .foregroundColor(.secondary)
+                    .font(.system(.body, design: .monospaced))
+            }
+            HStack {
+                Text(verbatim: "Patch state")
+                Spacer()
+                Text(viewModel.debugPatchState).foregroundColor(.secondary)
+            }
+
+            Button(action: { viewModel.debugRegenerateToken() }) {
+                Text(verbatim: "Regenerate session token")
+            }
+            Button(action: { viewModel.debugRestoreBackup() }) {
+                Text(verbatim: "Restore backup token")
+            }
+            Button(action: { viewModel.debugClearToken() }) {
+                Text(verbatim: "Clear session token")
+            }
+
+            HStack {
+                TextField("hex (8 chars)", text: $debugTokenInput)
+                    .autocorrectionDisabled(true)
+                    .textInputAutocapitalization(.never)
+                    .font(.system(.body, design: .monospaced))
+                Button(action: { _ = viewModel.debugSetToken(debugTokenInput) }) {
+                    Text(verbatim: "Set")
+                }
+                .disabled(debugTokenInput.isEmpty)
+            }
+
+            Button(action: { viewModel.debugForceReconnect() }) {
+                Text(verbatim: "Force reconnect (re-auth)")
+            }
+        } header: {
+            Text(verbatim: "DEBUG · Session token")
+        } footer: {
+            Text(verbatim: "Debug build only. On auth rejection (code 7) or an empty token the driver auto-retries with the backup token; use Restore/Set to recover manually. Token changes are logged.")
+        }
+        .onAppear { viewModel.debugRefreshToken() }
+    }
+    #endif
 
     var reservoirStatus: some View {
         VStack(alignment: .trailing, spacing: 5) {


### PR DESCRIPTION
Reworked per @bastiaanv's analysis (thanks!). The earlier approach (mint-fresh-token-at-prime + reconnect latch/backoff + clear-on-ejected) is reverted.

## Root cause

The auth token is the per-patch secret the patch binds at activation. The driver **deletes** it on force-deactivate (and never on terminal states). Because **force-deactivate does not disconnect**, `ensureConnected` short-circuits on the still-open connection, so a freshly generated token is **never re-sent** via `doAuthorize` — the patch stays bound to the old token while app state holds a different (or empty) one → **`responseCode 7`** (wrong token). Killing the app doesn't help; the bad/empty token is persisted.

## Fix (backup + restore)

- Add `MedtrumPumpState.backupSessionToken` (persisted).
- **Back up** the active token instead of deleting it, on deactivate, force-deactivate, and when the patch reaches a terminal state.
- **Terminal = `SessionTokenPolicy.isTerminal` = state `>= occlusion` (96)**: occlusion, expired, reservoir-empty, faults, battery-out, stopped. Deliberately **not `> 32`** — `active_alt` (33) and the suspends/paused (64–70) are recoverable and keep their token; transient `ejecting`/`ejected` (5/6) keep it too (clearing on `ejected` was the regression that wiped a live patch's token mid-activation).
- On a **documented auth rejection (`responseCode 7`)**, `doAuthorize` retries once with the backup token on the same connection (the patch responded, so it's still up).
- If the active token is **empty** and a backup exists, use the backup *before* sending auth — so we never depend on whatever code the patch returns for an empty token. (We intentionally do **not** assume the meaning of code `32`; it is undocumented and collides with the active-state value.)
- Route every token write through `setSessionToken(_:reason:)` and **log all manipulations when `MEDTRUM_DEBUG` is on**.
- Keep the original "generate token when empty" at prime.
- `MEDTRUM_DEBUG` session-token menu: show the backup token + add a Restore-backup action.

Per @bastiaanv, the reconnect flow is left as-is (no added delay/latch).

## Notes
- Debug menu compiled out unless `MEDTRUM_DEBUG` is set.
- Not built against full Xcode in this environment — please run tests/build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)