### PR TITLE
fix: prevent duplicated reservoir notify

### DIFF
--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -1062,7 +1062,7 @@ public extension MedtrumPumpManager {
             delegate?.pumpManager(
                 self,
                 didReadReservoirValue: self.state.reservoir.rounded(toPlaces: 1),
-                at: self.state.lastSync
+                at: Date.now
             ) { result in
                 switch result {
                 case let .failure(error):

--- a/MedtrumKit/PumpManager/StateSyncer.swift
+++ b/MedtrumKit/PumpManager/StateSyncer.swift
@@ -25,14 +25,16 @@ enum StateSyncer {
                 pumpManager.emitAlert(alertType: .lowReservoir(level: reservoir))
             }
 
-            state.reservoir = reservoir
-            if state.initialReservoir == nil {
-                state.initialReservoir = state.reservoir
-            }
+            if state.reservoir != reservoir {
+                state.reservoir = reservoir
+                if state.initialReservoir == nil {
+                    state.initialReservoir = state.reservoir
+                }
 
-            if fullSync {
-                // to prevent spaming the OSAID app with reservoir updates
-                pumpManager.emitReservoirLevel()
+                if fullSync {
+                    // to prevent spaming the OSAID app with reservoir updates
+                    pumpManager.emitReservoirLevel()
+                }
             }
         }
 


### PR DESCRIPTION
This PR force MedtrumKit to only emit reservoir updates if the actual reservoir levels have changed.

The `at: self.state.lastSync` was an error from the start, since the lastReconciliation date hasn't been updated yet

Closed #155 
Tagging @marionbarker 