### PR TITLE
fix: prevent double callback hit

### DIFF
--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -76,7 +76,13 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
             return
         }
 
+        var finished = false
         connectCompletion = { (_ result: MedtrumConnectError?) -> Void in
+            guard !finished else {
+                return
+            }
+            
+            finished = true
             self.connectCompletion = nil
             self.connectionTimeout?.cancel()
             self.connectionTimeout = nil

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -914,7 +914,6 @@ public extension MedtrumPumpManager {
         doseEntry.deliveredUnits = delivered
 
         if !completed {
-            notifyStateDidChange()
             return
         }
 


### PR DESCRIPTION
This PR fixes an issue, where MedtrumKit call the callback twice. In Trio, this will cause an app crash