### PR TITLE
fix: add backup flow for error code 7

### DIFF
--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -81,7 +81,7 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
             guard !finished else {
                 return
             }
-            
+
             finished = true
             self.connectCompletion = nil
             self.connectionTimeout?.cancel()

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -760,6 +760,7 @@ public extension MedtrumPumpManager {
 
             self.state.patchId = Data()
             self.state.pumpState = .none
+            self.state.backupSessionToken = self.state.sessionToken
             self.state.sessionToken = Data()
             self.state.lastSync = Date.now
             self.state.basalDose = suspendDose
@@ -793,6 +794,7 @@ public extension MedtrumPumpManager {
 
         state.patchId = Data()
         state.pumpState = .none
+        self.state.backupSessionToken = self.state.sessionToken
         state.sessionToken = Data()
         state.lastSync = Date.now
         state.basalDose = suspendDose

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -794,7 +794,7 @@ public extension MedtrumPumpManager {
 
         state.patchId = Data()
         state.pumpState = .none
-        self.state.backupSessionToken = self.state.sessionToken
+        state.backupSessionToken = state.sessionToken
         state.sessionToken = Data()
         state.lastSync = Date.now
         state.basalDose = suspendDose

--- a/MedtrumKit/PumpManager/MedtrumPumpState.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpState.swift
@@ -54,6 +54,7 @@ public class MedtrumPumpState: RawRepresentable {
         pumpSN = rawValue["pumpSN"] as? Data ?? Data()
         lowReservoirWarning = rawValue["lowReservoirWarning"] as? Double
         sessionToken = rawValue["sessionToken"] as? Data ?? Data()
+        backupSessionToken = rawValue["backupSessionToken"] as? Data ?? Data()
         patchId = rawValue["patchId"] as? Data ?? Data()
         patchActivatedAt = rawValue["patchActivatedAt"] as? Date ?? nil
         deviceType = rawValue["deviceType"] as? UInt8 ?? 0
@@ -137,6 +138,7 @@ public class MedtrumPumpState: RawRepresentable {
         lowReservoirWarning = nil
         bolusDose = nil
         sessionToken = Data()
+        backupSessionToken = Data()
         patchId = Data()
         patchActivatedAt = nil
         deviceType = 0
@@ -174,6 +176,7 @@ public class MedtrumPumpState: RawRepresentable {
         value["lowReservoirWarning"] = lowReservoirWarning
         value["pumpSN"] = pumpSN
         value["sessionToken"] = sessionToken
+        value["backupSessionToken"] = backupSessionToken
         value["patchId"] = patchId
         value["patchActivatedAt"] = patchActivatedAt
         value["patchGracePeriodFrom"] = patchGracePeriodFrom
@@ -214,6 +217,7 @@ public class MedtrumPumpState: RawRepresentable {
 
     // Patch specific data
     public var sessionToken: Data
+    public var backupSessionToken: Data
     public var patchId: Data
     public var patchActivatedAt: Date?
     public var patchGracePeriodFrom: Date? {

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -85,13 +85,20 @@ class PeripheralManager: NSObject {
 
 extension PeripheralManager {
     // Connect step 1
-    private func doAuthorize() {
+    private func doAuthorize(useBackupToken: Bool = false) {
+        let token = !useBackupToken ? pumpManager.state.sessionToken : pumpManager.state.backupSessionToken
         let authData = writePacket(
-            AuthorizePacket(pumpSN: pumpManager.state.pumpSN, sessionToken: pumpManager.state.sessionToken)
+            AuthorizePacket(pumpSN: pumpManager.state.pumpSN, sessionToken: token)
         )
 
         switch authData {
         case let .failure(error):
+            if !useBackupToken {
+                log.warning("Failed to complete authorization flow, falling back to backup token")
+                doAuthorize(useBackupToken: true)
+                return
+            }
+            
             log.error("Failed to complete authorization flow: \(error.localizedDescription)")
             bluetoothManager.disconnect()
             completion?(.failedToCompleteAuthorizationFlow(localizedError: error.localizedDescription))

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -98,7 +98,7 @@ extension PeripheralManager {
                 doAuthorize(useBackupToken: true)
                 return
             }
-            
+
             log.error("Failed to complete authorization flow: \(error.localizedDescription)")
             bluetoothManager.disconnect()
             completion?(.failedToCompleteAuthorizationFlow(localizedError: error.localizedDescription))


### PR DESCRIPTION
There are report where the user has filled the patch with insulin before going though the deactivation flow. In those cases, the patch gets activated with an old session token. If this happens, the new patch is useless because we've regenerated the session token and cannot authorize anymore.

This PR stores this old token for 1 deactivation to ensure that a new patch is still usable

