### PR TITLE
Fix: dosing issues

### DIFF
--- a/Common/NewPumpEvent.swift
+++ b/Common/NewPumpEvent.swift
@@ -4,11 +4,11 @@ import LoopKit
 public extension NewPumpEvent {
     private static let dateFormatter = ISO8601DateFormatter()
 
-    static func bolus(dose: DoseEntry, units: Double, date: Date = Date.now) -> NewPumpEvent {
+    static func bolus(dose: DoseEntry, scheduledUnits: Double, date: Date = Date.now) -> NewPumpEvent {
         NewPumpEvent(
             date: date,
             dose: dose,
-            raw: "\(DoseType.bolus.rawValue) \(units) \(dateFormatter.string(from: date))".data(using: .utf8) ?? Data([]),
+            raw: "\(DoseType.bolus.rawValue) \(scheduledUnits) \(dateFormatter.string(from: date))".data(using: .utf8) ?? Data([]),
             title: String(localized: "Bolus", comment: "Pump Event title for UnfinalizedDose with doseType of .bolus")
         )
     }
@@ -17,7 +17,7 @@ public extension NewPumpEvent {
         let dose = unfinalizedDose.toDoseEntry(isMutable: true)
         return NewPumpEvent.bolus(
             dose: dose,
-            units: dose.programmedUnits,
+            scheduledUnits: unfinalizedDose.value,
             date: dose.startDate
         )
     }

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -374,7 +374,7 @@ public extension MedtrumPumpManager {
             events.append(
                 NewPumpEvent.bolus(
                     dose: dose,
-                    units: dose.deliveredUnits ?? 0,
+                    scheduledUnits: dose.programmedUnits,
                     date: dose.startDate
                 )
             )

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -934,7 +934,7 @@ public extension MedtrumPumpManager {
         events.append(
             NewPumpEvent.bolus(
                 dose: dose,
-                units: dose.programmedUnits,
+                scheduledUnits: dose.programmedUnits,
                 date: dose.startDate
             )
         )
@@ -990,7 +990,7 @@ public extension MedtrumPumpManager {
         events.append(
             NewPumpEvent.bolus(
                 dose: dose,
-                units: dose.programmedUnits,
+                scheduledUnits: dose.programmedUnits,
                 date: dose.startDate
             )
         )

--- a/MedtrumKit/PumpManager/StateSyncer.swift
+++ b/MedtrumKit/PumpManager/StateSyncer.swift
@@ -10,9 +10,7 @@ enum StateSyncer {
         duringReconnect: Bool,
         fullSync: Bool
     ) {
-        if fullSync {
-            pumpManager.state.lastSync = Date.now
-        }
+        let syncDate = Date.now
 
         StateSyncer.updatePumpState(syncResponse: syncResponse, pumpManager: pumpManager)
 
@@ -38,6 +36,7 @@ enum StateSyncer {
             }
         }
 
+        var events: [NewPumpEvent] = []
         if let basal = syncResponse.basal {
             switch basal.type {
             case .ABSOLUTE_TEMP,
@@ -67,14 +66,11 @@ enum StateSyncer {
                     state.basalDose = UnfinalizedDose(suspendStartTime: eventTime)
                     let basalDose = state.basalDose.toDoseEntry()
 
-                    var events: [NewPumpEvent] = [NewPumpEvent.suspend(dose: basalDose, date: basalDose.startDate)]
+                    events.append(NewPumpEvent.suspend(dose: basalDose, date: basalDose.startDate))
                     if dose.type == .tempBasal {
                         // Record finalized temp basal, resume/basal is already finalized
                         events.append(NewPumpEvent.tempBasal(dose: dose, date: dose.startDate))
                     }
-
-                    pumpManager.emitPumpEvents(events)
-                    pumpManager.notifyStateDidChange()
                 }
 
                 state.basalState = .suspended
@@ -95,18 +91,14 @@ enum StateSyncer {
                         )
 
                     let basalDose = state.basalDose.toDoseEntry(isMutable: true)
-                    var events: [NewPumpEvent] = [
-                        basalDose.type == .resume ?
+                    events.append(basalDose.type == .resume ?
                             NewPumpEvent.resume(dose: basalDose, date: basalDose.startDate) :
                             NewPumpEvent.basal(dose: basalDose, date: basalDose.startDate)
-                    ]
+                    )
                     if dose.type == .tempBasal {
                         // Record finalized temp basal, suspend is already finalized
                         events.append(NewPumpEvent.tempBasal(dose: dose, date: dose.startDate))
                     }
-
-                    pumpManager.emitPumpEvents(events)
-                    pumpManager.notifyStateDidChange()
                 }
 
                 state.basalState = .active
@@ -140,6 +132,11 @@ enum StateSyncer {
             pumpManager.checkBolusDone()
         } else {
             pumpManager.state.bolusState = .noBolus
+        }
+        
+        if fullSync || !events.isEmpty {
+            pumpManager.state.lastSync = syncDate
+            pumpManager.emitPumpEvents(events)
         }
 
         pumpManager.notifyStateDidChange()

--- a/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
+++ b/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
@@ -550,6 +550,7 @@ struct MedtrumKitSettings: View {
                         if let tempRemaining = viewModel.tempBasalRemaining {
                             Text(tempRemaining)
                                 .foregroundColor(.secondary)
+                                .font(.caption)
                         }
                     }
                 }


### PR DESCRIPTION
Changes:
- Chapter 4 -> a NewPumpEvent. raw (for bolus type) does not rely on delivered units, but on scheduled units. This way a cancelled bolus does not change the raw value of the NewPumpEvent
- Chapter 6 -> Every full sync (or every sync with NewPumpEvent's) will trigger the hasNewPumpEvents and thus update the lastReconciliation date

(also added a small font change for the time remaining on a temp basal)

closes #152 
Tagging @marionbarker 