### PR TITLE
Fix silent tones toggle not reflecting persisted state

### DIFF
--- a/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
@@ -414,6 +414,11 @@ extension MedtrumKitSettingsViewModel {
         hourlyLimit = Int(state.maxHourlyInsulin)
         dailyLimit = Int(state.maxDailyInsulin)
 
+        // Reflect the persisted value; guard avoids re-persisting via didSet on every refresh
+        if useSilentTones != state.useSilentTones {
+            useSilentTones = state.useSilentTones
+        }
+
         if !state.patchId.isEmpty, let patchActivatedAt, let patchGracePeriodFrom {
             let totalLifetime = patchGracePeriodFrom.timeIntervalSince(patchActivatedAt)
             let progress = Date.now.timeIntervalSince1970 - patchActivatedAt.timeIntervalSince1970


### PR DESCRIPTION
## Problem
After enabling **Enable Silent tones** in the Medtrum settings, the toggle appears to revert to *off* whenever you re-open the settings screen, so it looks like the setting isn't sticking.

## Root cause
`MedtrumKitSettingsViewModel.updateState(_:)` hydrates every persisted field from the pump state **except** `useSilentTones`. The `@Published var useSilentTones` defaults to `false`, and its `didSet` only writes *to* state, never reads back *from* it.

Because the settings screen builds a fresh view model every time it's shown (created in `MedtrumKitUICoordinator`, held as `@ObservedObject`), and a `@Published` property's default value does not trigger `didSet`, the toggle always renders as `false` on (re)entry — regardless of the stored value.

The underlying setting *is* persisted correctly (it round-trips through `rawValue`), so silent tones actually stay active; only the toggle's displayed state is wrong. But this makes the feature look broken and hard to turn back off from the UI.

## Fix
Reflect the persisted value in `updateState(_:)`, guarded with an inequality check so it doesn't re-persist via the `didSet` observer on every status refresh:

```swift
if useSilentTones != state.useSilentTones {
    useSilentTones = state.useSilentTones
}
```

## Testing
- Enabled Silent tones, navigated out of Medtrum settings and back → toggle now stays enabled.
- Built and archived Loop with the change on top of `dev` (a7466b7); verified the toggle reflects the persisted value across screen re-entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)