### PR TITLE
fix reconnecting to a patch while the app is in the background

### DIFF
--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -113,6 +113,20 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
             return
         }
 
+        // We lost the reference but know which device we are paired with. Ask CoreBluetooth for it
+        // back rather than scanning: a connect to a known peripheral is honoured in the background
+        // (and stays pending until the pump is in range again), while a scan only ever discovers
+        // anything while the app is in the foreground.
+        if manager.state == .poweredOn,
+           let identifier = pumpManager?.state.peripheralIdentifier,
+           let peripheral = manager.retrievePeripherals(withIdentifiers: [identifier]).first
+        {
+            logger.info("Retrieved known peripheral \(identifier), reconnecting")
+            startTimeout(attempt, seconds: .seconds(15))
+            connect(peripheral: peripheral)
+            return
+        }
+
         let connectedDevices = manager.retrieveConnectedPeripherals(withServices: [CBUUID.SERVICE_UUID])
         if let peripheral = connectedDevices.first(where: { $0.name == "MT" }) {
             // Phone is already connected, but the app is not
@@ -154,8 +168,16 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
         }
     }
 
+    /// Arms the deadline for `attempt`, replacing any deadline already on it. Called at each point
+    /// the connect flow makes progress, so the allowance for waking up suspended starts over.
     private func startTimeout(_ attempt: ConnectAttempt, seconds: TimeInterval) {
+        attempt.remainingExtensions = ConnectAttempt.maxExtensions
+        armTimeout(attempt, seconds: seconds)
+    }
+
+    private func armTimeout(_ attempt: ConnectAttempt, seconds: TimeInterval) {
         attempt.timeout?.cancel()
+        attempt.armedAt = .now
 
         attempt.timeout = Task { [weak self, weak attempt] in
             do {
@@ -168,6 +190,22 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
             // The one condition that matters: is this still the attempt in flight? Covers being
             // superseded by a re-arm, and waking a moment before cancellation landed.
             guard let self, let attempt, self.attempt === attempt else {
+                return
+            }
+
+            // `Task.sleep` is frozen while iOS has the app suspended, so waking far past the budget
+            // means we were asleep for most of it rather than waiting on a pump that never answered
+            // - and we typically wake because the connection we were waiting for just arrived. Give
+            // the attempt the budget it never got instead of failing a connect that may be landing
+            // in this very instant. Bounded, so a phone that keeps suspending still terminates.
+            let elapsed = Date.now.timeIntervalSince(attempt.armedAt)
+            if elapsed > seconds * 2, attempt.remainingExtensions > 0 {
+                attempt.remainingExtensions -= 1
+                self.logger
+                    .warning(
+                        "Timeout woke after \(Int(elapsed))s of a \(Int(seconds))s budget - app was suspended, re-arming"
+                    )
+                self.armTimeout(attempt, seconds: seconds)
                 return
             }
 
@@ -206,9 +244,17 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
         }
     }
 
+    /// Forgets the device entirely - used when the patch is deactivated and when the pump base is
+    /// swapped for another one. It also drops the stored identifier, so the next connect has to
+    /// find the base by scanning, which is fine: both of those are foreground activities.
     func clearPeripheral() {
         peripheral = nil
         peripheralManager = nil
+
+        if pumpManager?.state.peripheralIdentifier != nil {
+            pumpManager?.state.peripheralIdentifier = nil
+            pumpManager?.notifyStateDidChange()
+        }
     }
 }
 
@@ -306,9 +352,9 @@ extension BluetoothManager {
     func centralManager(_: CBCentralManager, didConnect peripheral: CBPeripheral) {
         logger.info("Connected to pump: \(peripheral.name ?? "<NO_NAME>")!")
 
-        // Both guards below drop the link rather than just returning. `peripheral` is already set at
-        // this point, so bailing out would leave a live peripheral with no PeripheralManager behind
-        // it: the next ensureConnected reports "Already connect!" while every write fails with
+        // This guard drops the link rather than just returning. `peripheral` is already set at this
+        // point, so bailing out would leave a live peripheral with no PeripheralManager behind it:
+        // the next ensureConnected reports "Already connect!" while every write fails with
         // .noManager, and nothing clears that until the link happens to drop on its own.
         guard let pumpManager = pumpManager else {
             logger.warning("No pumpManager...")
@@ -316,17 +362,37 @@ extension BluetoothManager {
             return
         }
 
-        // The attempt this belongs to already gave up - typically its timeout fired while the pump
-        // was out of range, and it only came back now.
-        guard let attempt = attempt else {
-            logger.warning("No connectCompletion...")
-            disconnect(force: true)
-            return
+        // The attempt this belongs to already gave up - typically its deadline fired while the app
+        // was suspended, in the same instant the link finally came up. Do not throw the connection
+        // away: reconnecting to a known peripheral is the only thing that works while backgrounded,
+        // and dropping it here strands us on the scan path, which does not. Nobody is waiting on
+        // the result any more, so adopt it under an attempt of our own and finish the flow.
+        let attempt: ConnectAttempt
+        if let inFlight = self.attempt {
+            attempt = inFlight
+        } else {
+            logger.info("No connectCompletion, adopting the connection anyway")
+
+            attempt = ConnectAttempt { [weak self] (error: MedtrumConnectError?) in
+                if let error = error {
+                    self?.logger.error("Failed to complete adopted connection: \(error)")
+                } else {
+                    self?.logger.info("Adopted connection is ready")
+                }
+            }
+            self.attempt = attempt
         }
 
         forcedDisconnect = false
 
         self.peripheral = peripheral
+        // Remember what to reconnect to. Only identifiers that actually produced a connection get
+        // stored, and it survives an app restart, so the scan path is only ever needed for pairing.
+        if pumpManager.state.peripheralIdentifier != peripheral.identifier {
+            pumpManager.state.peripheralIdentifier = peripheral.identifier
+            pumpManager.notifyStateDidChange()
+        }
+
         peripheralManager = PeripheralManager(peripheral, self, pumpManager) { [weak self] error in
             self?.finish(attempt, error)
         }

--- a/MedtrumKit/PumpManager/ConnectAttempt.swift
+++ b/MedtrumKit/PumpManager/ConnectAttempt.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// One connect attempt: the caller waiting on it, and the deadline that guarantees they hear
 /// back. Connect, disconnect, timeout and the auth flow all race to report a result, so the
 /// attempt owns which of them wins rather than each site checking for itself.
@@ -5,6 +7,17 @@ final class ConnectAttempt {
     let completion: (MedtrumConnectError?) -> Void
     var timeout: Task<Void, Never>?
     private var reported = false
+
+    /// When the deadline currently in flight was armed. `Task.sleep` does not advance while iOS has
+    /// the app suspended, so a timeout that wakes far past its budget never actually spent it
+    /// waiting - see `BluetoothManager.startTimeout`.
+    var armedAt: Date = .now
+
+    static let maxExtensions = 2
+
+    /// How many times a deadline may still be re-armed after waking up suspended. Bounded so the
+    /// attempt always terminates, even if the app keeps getting suspended.
+    var remainingExtensions = ConnectAttempt.maxExtensions
 
     init(_ completion: @escaping (MedtrumConnectError?) -> Void) {
         self.completion = completion

--- a/MedtrumKit/PumpManager/MedtrumPumpState.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpState.swift
@@ -57,6 +57,7 @@ public class MedtrumPumpState: RawRepresentable {
         sessionToken = rawValue["sessionToken"] as? Data ?? Data()
         backupSessionToken = rawValue["backupSessionToken"] as? Data ?? Data()
         patchId = rawValue["patchId"] as? Data ?? Data()
+        peripheralIdentifier = (rawValue["peripheralIdentifier"] as? String).flatMap { UUID(uuidString: $0) }
         patchActivatedAt = rawValue["patchActivatedAt"] as? Date ?? nil
         deviceType = rawValue["deviceType"] as? UInt8 ?? 0
         swVersion = rawValue["swVersion"] as? String ?? "0.0.0"
@@ -136,6 +137,7 @@ public class MedtrumPumpState: RawRepresentable {
         sessionToken = Data()
         backupSessionToken = Data()
         patchId = Data()
+        peripheralIdentifier = nil
         patchActivatedAt = nil
         deviceType = 0
         swVersion = "0.0.0"
@@ -173,6 +175,7 @@ public class MedtrumPumpState: RawRepresentable {
         value["sessionToken"] = sessionToken
         value["backupSessionToken"] = backupSessionToken
         value["patchId"] = patchId
+        value["peripheralIdentifier"] = peripheralIdentifier?.uuidString
         value["patchActivatedAt"] = patchActivatedAt
         value["patchGracePeriodFrom"] = patchGracePeriodFrom
         value["patchExpiresAt"] = patchExpiresAt
@@ -215,6 +218,14 @@ public class MedtrumPumpState: RawRepresentable {
     public var sessionToken: Data
     public var backupSessionToken: Data
     public var patchId: Data
+
+    /// The CoreBluetooth identifier of the pump base we are paired with - the base carries the
+    /// radio, so this survives a patch change. iOS keeps it stable, which lets us get a
+    /// `CBPeripheral` back with `retrievePeripherals(withIdentifiers:)` instead of scanning. That
+    /// matters because scanning finds nothing while the app is in the background, whereas
+    /// reconnecting to a known peripheral is honoured there.
+    public var peripheralIdentifier: UUID?
+
     public var patchActivatedAt: Date?
     public var patchGracePeriodFrom: Date? {
         guard let activatedAt = patchActivatedAt else {


### PR DESCRIPTION
#170 introduced a regression: the driver can end up unable to reconnect to the pump while the app is
in the background, and stay that way until the app is foregrounded. This PR cleans it up.

## What goes wrong

Two changes in #170 interact badly.

1. The connect timeout lost its `peripheral.state == .connected` bail-out. That was removed for a
  reason: a link that is up but not yet *ready* (auth / synchronize / subscribe still to run) would
  otherwise leave the attempt in flight with nothing to clear it, wedging every later
  `ensureConnected`.
2. `didConnect` gained `disconnect(force: true)` on its no-attempt guard. Also for a reason: bailing
  out and leaving a live peripheral with no `PeripheralManager` meant `ensureConnected` would report
  `Already connect!` while every write failed with `.noManager`, and nothing cleared that.

Each is defensible alone. What was missing is a third factor: **`Task.sleep` does not advance while iOS
has the app suspended.**:

1. A 15-second connect timeout is armed. The app is suspended. The timeout wakes minutes late -
   typically *because* the connection it was waiting for has just arrived and woken the process.
2. With no bail-out, it fires anyway and clears the attempt.
3. `didConnect` lands in the same instant, finds no attempt, and force-disconnects - which also nils
   `peripheral`.
4. With no `peripheral`, `ensureConnected` falls back to `startScan`, and iOS returns no scan results
   to a backgrounded app that scans without a service filter.

From there the driver cannot reconnect until the app comes to the foreground.

This PR preserves the intended effect from #170, but in a correct way.

(Before #170, it was possible to end up with a half-initialised peripheral: no PeripheralManager, no service discovery.
After which, `ensureConnected` would report "Already connect!" while every write would fail with `.noManager`.
#170 went with the opposite extreme and destroyed the link outright, which was wrong.
"Adopting" (as implemented in this PR) completes the flow instead, so the connection ends up in exactly the state a normal connect would leave it in.)

## The fix

The code is Claude-generated. I reviewed it and tested it on a live device. Hopefully nothing slips through this time...

* **`didConnect` completes the connection instead of destroying it.** If the attempt is gone it
  creates one of its own and runs the flow. A live link is worth keeping - reconnecting to a known
  peripheral is the only thing that works in the background.
* **Connect timeouts can tell if they were suspended.** Waking past twice the budget means the budget
  was never actually spent waiting, so the timeout re-arms instead of failing. Bounded to 2
  extensions per progress point, so an attempt still always terminates. This restores the intent of
  the removed bail-out without bringing back the stranded attempt it was removed for.

This one is unrelated to the regression, but it aims to prevent any other potential "scan in the background" situation:
* **The pump base's CoreBluetooth identifier is persisted** (`MedtrumPumpState.peripheralIdentifier`)
  and `ensureConnected` recovers the `CBPeripheral` with `retrievePeripherals(withIdentifiers:)`
  before considering a scan. *Not part of the regression* - see the section below for why it is here.

---

## How it showed up

I walked away from the phone for ~10 minutes, came back, walked away again for ~20, came back, and
then left the phone locked for another ~20 minutes. When I unlocked it I saw a bunch of failed loops:
36 minutes with no pump connection, CGM readings arriving the whole time, every attempt ending in `Timeout reached`.

The app had been in the background since 20:22:51 and was not foregrounded again until 22:12:30
(iAPS `APPLICATION PHASE` log).

[medtrum_log_no_connect.txt](https://github.com/user-attachments/files/30625404/medtrum_log_no_connect.txt)

| time | real world | driver | log |
|---|---|---|---|
| 21:07:29 | phone with me, loop OK | connected | CGM seq 1421 |
| ~21:09 | **walked away from the phone** | link drops, reconnect armed (15 s) | `Device disconnected … timed out unexpectedly` → `Connecting to <CBPeripheral …>` |
| ~21:12 | still away | pending connect waits (correct) | CGM seq 1422 **missing** |
| 21:16:39 | **came back into range** | pending connect succeeds - and is thrown away | see below |
| 21:17:28 | phone with me | scan #1 finds nothing | CGM seq 1423 |
| 21:17 – 21:33 | **phone with me, pump in range** | 8 scans, all fail | CGM 1424-1426 |
| 21:33 – 21:52 | **away again (~19 min)** | scans fail (legitimately) | CGM 1427-1429 **missing** |
| 21:52 – 22:08 | **phone with me, pump in range** | 8 scans, all fail | CGM 1430-1433 |
| 22:12:30 | **unlocked the phone** | scan finds the pump in 2 s | app → `active` |

The three lines where it goes wrong, all in the same second:

```
21:09:58  Device disconnected, name: MT, error: The connection has timed out unexpectedly.
21:09:58  Connecting to <CBPeripheral: …, identifier = C8EC4E80-…>      ← 15 s timeout armed
          … app suspended, Task.sleep frozen …
21:16:39  ERROR   Failed to connect: Timeout reached...                 ← 6 m 41 s late
21:16:39  INFO    Connected to pump: MT!                                ← the link came up
21:16:39  WARNING No connectCompletion...                               ← → disconnect(force: true)
```

The timeout won the race, cleared the attempt, and `didConnect` discarded a connection that had just
succeeded - along with `peripheral`. Everything after that is the scan path:

```
21:17:28  Started scanning
21:17:44  Failed to connect: Timeout reached...
21:17:47  Started scanning
21:18:03  Failed to connect: Timeout reached...
…                                                    16 scans, 16 failures
22:12:28  Started scanning                           ← still background, finding nothing
22:12:29  APPLICATION PHASE: inactive
22:12:30  APPLICATION PHASE: active
22:12:30  Connecting to <CBPeripheral: … name = MT>  ← found in the same second
```

---

## Verification

[medtrum_log_fridge.txt](https://github.com/user-attachments/files/30625408/medtrum_log_fridge.txt)

**The same scenario, reproduced.** Phone into a fridge 🤣 for 10 minutes, out, left locked for another
10, then unlocked. App was in the background with Low Power mode on.

| time | real world | driver                                                    | log |
|---|---|-----------------------------------------------------------|---|
| 01:47:30 | phone on the desk | loop syncs normally                                       | `Already connect!` → `Manual sync:` |
| ~01:49 | **phone into the fridge** | link drops, reconnect armed (15 s)                        | `Device disconnected … timed out unexpectedly` |
| ~01:50 | phone suspended by iOS | pending connect waits                                     | (no log activity) |
| 01:51:55 | brief connect through the door | timeout recognises suspension, re-arms; link kept | see below |
| 01:51:57 | still in the fridge | link drops mid-auth                                       | `The specified device has disconnected` |
| ~01:59 | **out of the fridge**, still locked | app still suspended, nothing to wake it                   | (no log activity) |
| 02:02:29 | first loop cycle after | reconnects on the retained peripheral                     | `Connecting to …` → `Connected` in 2 s |
| 02:02:35 | | temp basal set                                            | `Set temp basal!` |

```
01:49:38  Device disconnected, name: MT, error: The connection has timed out unexpectedly.
01:49:38  Connecting to <CBPeripheral: …, identifier = C8EC4E80-…>      ← 15 s timeout armed
          … app suspended …
01:51:55  WARNING Timeout woke after 137s of a 15s budget - app was suspended, re-arming
01:51:55  INFO    Connected to pump: MT!                                ← attempt still in flight
01:51:56  Notify enabled and ready to start auth flow!
```

The timeout fix prevents the attempt from being cleared in the first place.

The other thing that I tested (separately) was the "`didConnect` adopts a connection" (see below). 

I temporarily cleared the attempt on every `connect()` (directly in the code) and let it run:

```
04:34:40  Retrieved known peripheral C8EC4E80-…, reconnecting
04:34:40  Connecting to <CBPeripheral: …>
04:34:40  Failed to auto reconnect on boot: failedToConnectToDevice   ← attempt cleared (test only)
04:34:40  Connected to pump: MT!
04:34:40  No connectCompletion, adopting the connection anyway
04:34:41  Notify enabled and ready to start auth flow!
04:34:42  State update: {…}
04:34:42  Connected to pump!
04:34:42  Adopted connection is ready
04:34:58  Sync pump data → Already connect!
04:35:03  Manual sync: {…}                                            ← link usable
```

---

## Changes

### `didConnect` adopts a connection nobody is waiting for

```
before                                     after
──────────────────────────────────────     ──────────────────────────────────────
timeout fires  → attempt = nil             timeout fires  → attempt = nil
didConnect      → attempt == nil           didConnect      → attempt == nil

      this was part 2 of the regression:          
                → disconnect(force: true)                  → create an attempt, adopt
                
                → peripheral = nil                         → "adopting the connection anyway"
ensureConnected → scan → (background)                      → auth / sync / subscribe
                → nothing, forever         link kept, next loop cycle works
```

### Suspension-aware timeouts

```
before                                     after
──────────────────────────────────────     ──────────────────────────────────────
arm 15 s timeout                           arm 15 s timeout, record armedAt
  [suspended - Task.sleep frozen]            [suspended - Task.sleep frozen]
wake 401 s later                           wake 137 s later
→ fire → attempt = nil                     → elapsed > 2x budget → re-arm (2 left)
→ didConnect finds nothing                 → didConnect finds its attempt
```

`startTimeout` resets the allowance and is called at each real progress point; the suspension re-arm
uses `armTimeout`, which does not - so the allowance cannot be refreshed by the artifact it is meant
to absorb, and the attempt always terminates.

### Persisted peripheral identifier

Not part of the regression (and it would not have prevented the incident above) - with the two fixes
above, `peripheral` survives as it should and the scan path is never reached.

It is here because the `peripheral == nil` → scan path runs on any launch where BLE state restoration
doesn't return the peripheral: 7 times in one day of logs, if any of those happened in the background, the connect would have failed.
Persisting the identifier means reconnection never depends on scanning.

```
before                                     after
──────────────────────────────────────     ──────────────────────────────────────
ensureConnected, peripheral == nil         ensureConnected, peripheral == nil
→ retrieveConnectedPeripherals (empty)     → retrievePeripherals(withIdentifiers: [saved])
→ startScan                                → connect()
→ backgrounded: no discovery, ever         → honoured in the background, stays pending
→ 15 s → failedToConnectToDevice             until the pump is back in range
```

### `clearPeripheral()` clears the identifier too

On patch deactivation and pump base change. Without it a stale identifier would outlive a base swap,
`retrievePeripherals` would hand back the old base, and the connect would sit pending against a device
that is never coming back instead of falling through to a scan.

