### PR TITLE
fix an infinite notifyStateDidChange() loop

### DIFF
--- a/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
@@ -51,6 +51,11 @@ class MedtrumKitSettingsViewModel: PatchLifetimeFormatting, ObservableObject, Pu
     
     @Published var useSilentTones = false {
         didSet {
+            // prevent infinite loop: notifyStateDidChange() -> notify observers -> notify this view model -> set useSilentTones -> notifyStateDidChange() -> ...
+            guard pumpManager?.state.useSilentTones != useSilentTones else {
+                return
+            }
+
             pumpManager?.state.useSilentTones = useSilentTones
             pumpManager?.notifyStateDidChange()
         }


### PR DESCRIPTION
Opening the pump settings view starts a never-ending cascade of `notifyStateDidChange()`:
* `var useSilentTones` is initialized
* `didSet` fires
* it calls `pumpManager?.notifyStateDidChange()`
* `notifyStateDidChange` notifies its observers
* one of the observers is the view model itself
* the `useSilentTones` var gets assigned
* `useSilentTones` `didSet` fires again -> and the loop repeats

The main thread gets saturated, the host app gets spammed with `pumpManager(_:didUpdate:oldStatus:)`.