### PR TITLE
add the missing pumpManagerBLEHeartbeatDidFire

### DIFF
--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -156,9 +156,12 @@ public class MedtrumPumpManager: DeviceManager {
     private var mustProvideBLEHeartbeat = false
     private var lastHeartbeat: Date = .distantPast
 
-    /// fired whenever the patch pushes a fresh state.
+    private static let heartbeatInterval: TimeInterval = .minutes(1)
+
     func issueHeartbeatIfNeeded() {
-        guard mustProvideBLEHeartbeat, Date.now.timeIntervalSince(lastHeartbeat) > .minutes(2) else {
+        guard mustProvideBLEHeartbeat,
+              Date.now.timeIntervalSince(lastHeartbeat) > Self.heartbeatInterval
+        else {
             return
         }
 

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -153,6 +153,28 @@ public class MedtrumPumpManager: DeviceManager {
         )
     }
     
+    private var mustProvideBLEHeartbeat = false
+    private var lastHeartbeat: Date = .distantPast
+
+    /// fired whenever the patch pushes a fresh state.
+    func issueHeartbeatIfNeeded() {
+        guard mustProvideBLEHeartbeat, Date.now.timeIntervalSince(lastHeartbeat) > .minutes(2) else {
+            return
+        }
+
+        lastHeartbeat = Date.now
+        log.info("Firing BLE heartbeat")
+
+        pumpDelegate.notify { delegate in
+            guard let delegate = delegate else {
+                self.log.error("Heartbeat fire could not be reported -> Missing delegate")
+                return
+            }
+
+            delegate.pumpManagerBLEHeartbeatDidFire(self)
+        }
+    }
+
     private let backgroundTask = BackgroundTask()
     @objc func appMovedToBackground() {
         if state.useSilentTones {
@@ -278,7 +300,9 @@ public extension MedtrumPumpManager {
         }
     }
 
-    func setMustProvideBLEHeartbeat(_: Bool) {}
+    func setMustProvideBLEHeartbeat(_ mustProvideBLEHeartbeat: Bool) {
+        self.mustProvideBLEHeartbeat = mustProvideBLEHeartbeat
+    }
 
     func createBolusProgressReporter(reportingOn: DispatchQueue) -> (any LoopKit.DoseProgressReporter)? {
         if let doseEntry = state.bolusDose {

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -198,6 +198,8 @@ extension PeripheralManager {
             duringReconnect: duringReconnect,
             fullSync: fullSync
         )
+
+        pumpManager.issueHeartbeatIfNeeded()
     }
 }
 

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -278,7 +278,7 @@ extension PeripheralManager: CBPeripheralDelegate {
 
         if characteristic.uuid == CBUUID.READ_UUID {
             guard data[1] != 0x00 else {
-                // Ignore all ping messages from patch pomp
+                pumpManager.issueHeartbeatIfNeeded()
                 return
             }
 


### PR DESCRIPTION
* respect `mustProvideBLEHeartbeat` from the host app (previously noop)
* when `mustProvideBLEHeartbeat == true`, call `pumpManagerBLEHeartbeatDidFire` (at most once per minute):
  * whenever the patch pushes an update 
  * whenever there is a ping from the pump (previously ignored)

~~Plus cherry-picked the fix from https://github.com/jbr7rr/MedtrumKit/pull/179~~ - removed this commit from here since it's already in `dev` (force-pushed)

