### PR TITLE
stable IDs and preserve in-flight pump events

### DIFF
--- a/Common/NewPumpEvent.swift
+++ b/Common/NewPumpEvent.swift
@@ -4,57 +4,53 @@ import LoopKit
 public extension NewPumpEvent {
     private static let dateFormatter = ISO8601DateFormatter()
 
-    static func bolus(dose: DoseEntry, scheduledUnits: Double, date: Date = Date.now) -> NewPumpEvent {
+    static func bolus(dose: DoseEntry) -> NewPumpEvent {
         NewPumpEvent(
-            date: date,
+            date: dose.startDate,
             dose: dose,
-            raw: "\(DoseType.bolus.rawValue) \(scheduledUnits) \(dateFormatter.string(from: date))".data(using: .utf8) ?? Data([]),
+            raw: "\(DoseType.bolus.rawValue) \(dose.programmedUnits) \(dateFormatter.string(from: dose.startDate))"
+                .data(using: .utf8) ?? Data([]),
             title: String(localized: "Bolus", comment: "Pump Event title for UnfinalizedDose with doseType of .bolus")
         )
     }
 
     static func bolus(unfinalizedDose: UnfinalizedDose) -> NewPumpEvent {
-        let dose = unfinalizedDose.toDoseEntry(isMutable: true)
-        return NewPumpEvent.bolus(
-            dose: dose,
-            scheduledUnits: unfinalizedDose.value,
-            date: dose.startDate
-        )
+        NewPumpEvent.bolus(dose: unfinalizedDose.toDoseEntry(isMutable: true))
     }
 
-    static func tempBasal(dose: DoseEntry, date: Date = Date.now) -> NewPumpEvent {
+    static func tempBasal(dose: DoseEntry) -> NewPumpEvent {
         NewPumpEvent(
-            date: date,
+            date: dose.startDate,
             dose: dose,
-            raw: "\(DoseType.tempBasal.rawValue) \(dose.programmedUnits) \(dateFormatter.string(from: date))"
+            raw: "\(DoseType.tempBasal.rawValue) \(dose.unitsPerHour) \(dateFormatter.string(from: dose.startDate))"
                 .data(using: .utf8) ?? Data([]),
             title: String(localized: "Temp Basal", comment: "Pump Event title for UnfinalizedDose with doseType of .tempBasal")
         )
     }
 
-    static func basal(dose: DoseEntry, date: Date = Date.now) -> NewPumpEvent {
+    static func basal(dose: DoseEntry) -> NewPumpEvent {
         NewPumpEvent(
-            date: date,
+            date: dose.startDate,
             dose: dose,
-            raw: "\(DoseType.basal.rawValue) \(dateFormatter.string(from: date))".data(using: .utf8) ?? Data([]),
+            raw: "\(DoseType.basal.rawValue) \(dateFormatter.string(from: dose.startDate))".data(using: .utf8) ?? Data([]),
             title: String(localized: "Basal", comment: "Pump Event title for UnfinalizedDose with doseType of .basal")
         )
     }
 
-    static func resume(dose: DoseEntry, date: Date = Date.now) -> NewPumpEvent {
+    static func resume(dose: DoseEntry) -> NewPumpEvent {
         NewPumpEvent(
-            date: date,
+            date: dose.startDate,
             dose: dose,
-            raw: "\(DoseType.resume.rawValue) \(dateFormatter.string(from: date))".data(using: .utf8) ?? Data([]),
+            raw: "\(DoseType.resume.rawValue) \(dateFormatter.string(from: dose.startDate))".data(using: .utf8) ?? Data([]),
             title: String(localized: "Resume", comment: "Pump Event title for UnfinalizedDose with doseType of .resume")
         )
     }
 
-    static func suspend(dose: DoseEntry, date: Date = Date.now) -> NewPumpEvent {
+    static func suspend(dose: DoseEntry) -> NewPumpEvent {
         NewPumpEvent(
-            date: date,
+            date: dose.startDate,
             dose: dose,
-            raw: "\(DoseType.suspend.rawValue) \(dateFormatter.string(from: date))".data(using: .utf8) ?? Data([]),
+            raw: "\(DoseType.suspend.rawValue) \(dateFormatter.string(from: dose.startDate))".data(using: .utf8) ?? Data([]),
             title: String(localized: "Suspended", comment: "Pump Event title for UnfinalizedDose with doseType of .suspend")
         )
     }

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -422,14 +422,8 @@ public extension MedtrumPumpManager {
             }
 
             let dose = doseEntry.toDoseEntry()
-            var events = self.getActivePumpEvents(endDate: nil)
-            events.append(
-                NewPumpEvent.bolus(
-                    dose: dose,
-                    scheduledUnits: dose.programmedUnits,
-                    date: dose.startDate
-                )
-            )
+            var events = self.runningTempBasal()
+            events.append(NewPumpEvent.bolus(dose: dose))
 
             self.state.bolusDose = nil
             self.state.cancelingBolusSince = nil
@@ -514,13 +508,8 @@ public extension MedtrumPumpManager {
                 insulinType: self.state.insulinType,
                 automatic: automatic
             )
-            var events = self.getActivePumpEvents(endDate: Date.now)
-            events.append(
-                NewPumpEvent.tempBasal(
-                    dose: tempBasalDose.toDoseEntry(isMutable: true),
-                    date: tempBasalDose.startDate
-                )
-            )
+            var events = self.finalizedTempBasal(endedAt: Date.now)
+            events.append(NewPumpEvent.tempBasal(dose: tempBasalDose.toDoseEntry(isMutable: true)))
 
             self.state.basalDose = tempBasalDose
             self.state.basalState = .tempBasal
@@ -535,27 +524,17 @@ public extension MedtrumPumpManager {
 
     private func reportScheduledBasal() {
         let now = Date.now
-        var events = getActivePumpEvents(endDate: now)
+        var events = finalizedTempBasal(endedAt: now)
 
-        // Maybe the temp basal already expired
-        // So only add the basal event if it isn't already in the list
-        if !events.contains(where: { $0.type == .basal }) {
-            let basalDose = UnfinalizedDose(
-                basalRate: state.currentBaseBasalRate,
-                insulinType: state.insulinType,
-                startDate: now
-            )
+        let basalDose = UnfinalizedDose(
+            basalRate: state.currentBaseBasalRate,
+            insulinType: state.insulinType,
+            startDate: now
+        )
 
-            events.append(
-                NewPumpEvent.basal(
-                    dose: basalDose.toDoseEntry(),
-                    date: now
-                )
-            )
+        events.append(NewPumpEvent.basal(dose: basalDose.toDoseEntry()))
 
-            state.basalDose = basalDose
-        }
-
+        state.basalDose = basalDose
         state.lastSync = Date.now
         notifyStateDidChange()
 
@@ -586,7 +565,7 @@ public extension MedtrumPumpManager {
             let start = Date.now
             let basalDose = UnfinalizedDose(suspendStartTime: start)
 
-            var events = self.getActivePumpEvents(endDate: start)
+            var events = self.finalizedTempBasal(endedAt: start)
             events.append(NewPumpEvent.suspend(dose: basalDose.toDoseEntry()))
 
             self.state.basalDose = basalDose
@@ -602,7 +581,7 @@ public extension MedtrumPumpManager {
     }
 
     func resumeDelivery(completion: @escaping ((any Error)?) -> Void) {
-        log.info("Suspending delivery...")
+        log.info("Resuming delivery...")
 
         ensureConnectedAndActive { error in
             if let error = error {
@@ -625,8 +604,8 @@ public extension MedtrumPumpManager {
                 insulinType: self.state.insulinType
             )
 
-            var events = self.getActivePumpEvents()
-            events.append(NewPumpEvent.resume(dose: resumeDose.toDoseEntry(), date: resumeDose.startDate))
+            var events = self.runningTempBasal()
+            events.append(NewPumpEvent.resume(dose: resumeDose.toDoseEntry()))
 
             self.state.basalDose = resumeDose
             self.state.basalState = .active
@@ -778,7 +757,7 @@ public extension MedtrumPumpManager {
                 )
                 let events = [
                     NewPumpEvent.replacedPump(date: start),
-                    NewPumpEvent.resume(dose: resumeDose.toDoseEntry(), date: resumeDose.startDate)
+                    NewPumpEvent.resume(dose: resumeDose.toDoseEntry())
                 ]
 
                 self.state.initialReservoir = nil
@@ -828,7 +807,8 @@ public extension MedtrumPumpManager {
             let suspendStart = Date.now
             let suspendDose = UnfinalizedDose(suspendStartTime: suspendStart)
 
-            var events = self.getActivePumpEvents(endDate: suspendStart)
+            var events = self.finalizedTempBasal(endedAt: suspendStart)
+            events.append(contentsOf: self.finalizeInterruptedBolus())
             events.append(NewPumpEvent.suspend(dose: suspendDose.toDoseEntry()))
 
             self.state.patchId = Data()
@@ -849,9 +829,12 @@ public extension MedtrumPumpManager {
     }
 
     func forceDeactivatePatch() {
+        log.info("Force deactivating patch...")
+
         let suspendDose = UnfinalizedDose(suspendStartTime: Date.now)
 
-        var events = getActivePumpEvents(endDate: Date.now)
+        var events = finalizedTempBasal(endedAt: Date.now)
+        events.append(contentsOf: finalizeInterruptedBolus())
         events.append(NewPumpEvent.suspend(dose: suspendDose.toDoseEntry()))
 
         state.previousPatch = PreviousPatch(
@@ -993,14 +976,8 @@ public extension MedtrumPumpManager {
         }
 
         let dose = doseEntry.toDoseEntry(useEstimatedEndDate: useEstimatedEndDate)
-        var events = getActivePumpEvents()
-        events.append(
-            NewPumpEvent.bolus(
-                dose: dose,
-                scheduledUnits: dose.programmedUnits,
-                date: dose.startDate
-            )
-        )
+        var events = runningTempBasal()
+        events.append(NewPumpEvent.bolus(dose: dose))
 
         state.bolusDose = nil
         state.lastSync = Date.now
@@ -1023,17 +1000,9 @@ public extension MedtrumPumpManager {
                     break
                 }
             }
-            delegate.pumpManager(
-                self,
-                hasNewPumpEvents: events,
-                lastReconciliation: self.state.lastSync,
-                replacePendingEvents: true
-            ) { error in
-                if let error = error {
-                    self.handlePumpDelegateError(method: "hasNewPumpEvents", error)
-                }
-            }
         }
+
+        emitPumpEvents(events)
     }
 
     func checkBolusDone() {
@@ -1048,14 +1017,8 @@ public extension MedtrumPumpManager {
         // due to being disconnected for too long
         doseEntry.deliveredUnits = doseEntry.value
         let dose = doseEntry.toDoseEntry(useEstimatedEndDate: true)
-        var events = getActivePumpEvents()
-        events.append(
-            NewPumpEvent.bolus(
-                dose: dose,
-                scheduledUnits: dose.programmedUnits,
-                date: dose.startDate
-            )
-        )
+        var events = runningTempBasal()
+        events.append(NewPumpEvent.bolus(dose: dose))
 
         state.lastSync = Date.now
         state.bolusDose = nil
@@ -1068,17 +1031,33 @@ public extension MedtrumPumpManager {
             }
 
             delegate.pumpManager(self, didError: .uncertainDelivery)
-            delegate.pumpManager(
-                self,
-                hasNewPumpEvents: events,
-                lastReconciliation: self.state.lastSync,
-                replacePendingEvents: true
-            ) { error in
-                if let error = error {
-                    self.handlePumpDelegateError(method: "hasNewPumpEvents", error)
-                }
-            }
         }
+
+        emitPumpEvents(events)
+    }
+
+    private func finalizeInterruptedBolus() -> [NewPumpEvent] {
+        guard let doseEntry = state.bolusDose else {
+            return []
+        }
+
+        log.warning(
+            "Patch deactivated during a bolus... \(doseEntry.deliveredUnits) U of the \(doseEntry.value) U"
+        )
+
+        let dose = doseEntry.toDoseEntry()
+        state.bolusDose = nil
+
+        pumpDelegate.notify { delegate in
+            guard let delegate = delegate else {
+                self.log.warning("No pump delegate, not notifying...")
+                return
+            }
+
+            delegate.pumpManager(self, didError: .uncertainDelivery)
+        }
+
+        return [NewPumpEvent.bolus(dose: dose)]
     }
 
     private func ensureConnectedAndActive(_ completion: @escaping (MedtrumConnectError?) -> Void) {
@@ -1115,18 +1094,22 @@ public extension MedtrumPumpManager {
         )
     }
 
-    private func getActivePumpEvents(endDate: Date? = nil) -> [NewPumpEvent] {
+    /// The current temp basal (if any), reported as still running
+    private func runningTempBasal() -> [NewPumpEvent] {
         guard state.basalDose.type == .tempBasal else {
             return []
         }
 
-        let basalEntry = state.basalDose.toDoseEntry(isMutable: endDate == nil, endDate: endDate ?? Date.now)
-        return [
-            NewPumpEvent.tempBasal(
-                dose: basalEntry,
-                date: basalEntry.startDate
-            )
-        ]
+        return [NewPumpEvent.tempBasal(dose: state.basalDose.toDoseEntry(isMutable: true))]
+    }
+
+    /// The current temp basal (if any), finalized as having stopped at `endedAt`
+    private func finalizedTempBasal(endedAt: Date) -> [NewPumpEvent] {
+        guard state.basalDose.type == .tempBasal else {
+            return []
+        }
+
+        return [NewPumpEvent.tempBasal(dose: state.basalDose.toDoseEntry(isMutable: false, endDate: endedAt))]
     }
 
     func emitReservoirLevel() {
@@ -1147,6 +1130,21 @@ public extension MedtrumPumpManager {
     }
 
     func emitPumpEvents(_ events: [NewPumpEvent], replacePendingEvents: Bool = true) {
+        var events = events
+
+        // With `replacePendingEvents` the host drops every mutable dose it holds.
+        // Anything still in flight has to be in here, otherwise it disappears from
+        // the host's history until we report it again later.
+        if replacePendingEvents {
+            if let bolusDose = state.bolusDose, !events.contains(where: { $0.type == .bolus }) {
+                events.append(NewPumpEvent.bolus(unfinalizedDose: bolusDose))
+            }
+
+            if !events.contains(where: { $0.type == .tempBasal }) {
+                events.append(contentsOf: runningTempBasal())
+            }
+        }
+
         pumpDelegate.notify { delegate in
             guard let delegate = delegate else {
                 self.log.warning("No pump delegate, not notifying...")

--- a/MedtrumKit/PumpManager/StateSyncer.swift
+++ b/MedtrumKit/PumpManager/StateSyncer.swift
@@ -66,39 +66,43 @@ enum StateSyncer {
                     state.basalDose = UnfinalizedDose(suspendStartTime: eventTime)
                     let basalDose = state.basalDose.toDoseEntry()
 
-                    events.append(NewPumpEvent.suspend(dose: basalDose, date: basalDose.startDate))
+                    events.append(NewPumpEvent.suspend(dose: basalDose))
                     if dose.type == .tempBasal {
                         // Record finalized temp basal, resume/basal is already finalized
-                        events.append(NewPumpEvent.tempBasal(dose: dose, date: dose.startDate))
+                        events.append(NewPumpEvent.tempBasal(dose: dose))
                     }
                 }
 
                 state.basalState = .suspended
 
             default:
-                if state.basalDose.type == .suspend || state.basalDose.type == .tempBasal {
-                    // unfinalized dose is finalized!
-                    let eventTime = Date.now
-                    let dose = state.basalDose.toDoseEntry(isMutable: false, endDate: eventTime)
-                    state.basalDose = dose.type == .tempBasal ?
-                        UnfinalizedDose(
-                            basalRate: state.currentBaseBasalRate,
-                            insulinType: state.insulinType
-                        ) :
-                        UnfinalizedDose(
-                            resumeStartTime: eventTime,
-                            insulinType: state.insulinType
-                        )
+                // The patch is delivering on its schedule again
+                let eventTime = Date.now
 
-                    let basalDose = state.basalDose.toDoseEntry(isMutable: true)
-                    events.append(basalDose.type == .resume ?
-                            NewPumpEvent.resume(dose: basalDose, date: basalDose.startDate) :
-                            NewPumpEvent.basal(dose: basalDose, date: basalDose.startDate)
+                switch state.basalDose.type {
+                case .tempBasal:
+                    // A temp basal was running - finalize it, and go back to scheduled basal
+                    let finishedTempBasal = state.basalDose.toDoseEntry(isMutable: false, endDate: eventTime)
+                    state.basalDose = UnfinalizedDose(
+                        basalRate: state.currentBaseBasalRate,
+                        insulinType: state.insulinType
                     )
-                    if dose.type == .tempBasal {
-                        // Record finalized temp basal, suspend is already finalized
-                        events.append(NewPumpEvent.tempBasal(dose: dose, date: dose.startDate))
-                    }
+
+                    events.append(NewPumpEvent.basal(dose: state.basalDose.toDoseEntry()))
+                    // Record finalized temp basal, the scheduled basal above is already finalized
+                    events.append(NewPumpEvent.tempBasal(dose: finishedTempBasal))
+
+                case .suspend:
+                    // Delivery was suspended - report the resume. The suspend is already finalized.
+                    state.basalDose = UnfinalizedDose(
+                        resumeStartTime: eventTime,
+                        insulinType: state.insulinType
+                    )
+
+                    events.append(NewPumpEvent.resume(dose: state.basalDose.toDoseEntry()))
+
+                default:
+                    break
                 }
 
                 state.basalState = .active
@@ -130,7 +134,7 @@ enum StateSyncer {
         } else if duringReconnect {
             pumpManager.checkBolusDone()
         }
-        
+
         if fullSync || !events.isEmpty {
             pumpManager.state.lastSync = syncDate
             pumpManager.emitPumpEvents(events)


### PR DESCRIPTION
* NewPumpEvent: derive events solely from the dose
* NewPumpEvent: TBR - use unitsPerHour to preserve stable IDs (programmedUnits is not stable)
* emitPumpEvents: re-add current in-flight pump events if needed
* StateSyncer: minor refactoring for the default case branch (no logic change)
* emit .uncertainDelivery + finalized bolus event when patch is deactivated during bolus

Might be related to this: https://github.com/jbr7rr/MedtrumKit/issues/168 (in-flight TBR or bolus events could have been lost previously)