### PR TITLE
better syncs

### DIFF
--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -42,6 +42,12 @@ public class MedtrumPumpManager: DeviceManager {
         bluetooth.pumpManager = self
     }
 
+    /// Patch clock drift only feeds a settings badge (`shouldShowTimeWarning`) and nothing in the
+    /// dosing path, but `fetchPatchTime` is a second BLE round trip and used to run on every
+    /// single sync - a second command per sync, several hundred a day, to watch a value that
+    /// moves by seconds per day.
+    static let patchTimeRefreshInterval: TimeInterval = .minutes(30)
+
     public required convenience init?(rawState: RawStateValue) {
         self.init(state: MedtrumPumpState(rawValue: rawState))
     }
@@ -269,7 +275,7 @@ public extension MedtrumPumpManager {
             }
 
             let syncResult = self.bluetooth.write(SynchronizePacket())
-            StateSyncer.fetchPatchTime(pumpManager: self)
+            StateSyncer.fetchPatchTimeIfStale(pumpManager: self)
 
             switch syncResult {
             case let .failure(error):

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -42,7 +42,6 @@ public class MedtrumPumpManager: DeviceManager {
         bluetooth.pumpManager = self
     }
 
-
     /// background sync, doesn't lock loops
     static let heartbeatSyncFreshnessInterval: TimeInterval = .minutes(2.5)
 

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -42,39 +42,13 @@ public class MedtrumPumpManager: DeviceManager {
         bluetooth.pumpManager = self
     }
 
-    // There are two doors into the full `SynchronizePacket` round trip, and they deliberately
-    // hold *different* thresholds, because they cost completely different things.
-    //
-    // Both measure the age of `state.lastSync`, which only advances on a full sync or on a
-    // notification that actually changed something - so it tracks "when we last had a complete
-    // picture", and these thresholds are how long we are willing to go without one.
-    //
-    // The patch does notify frequently (measured at roughly one frame every 7s), but the great
-    // majority carry only CGM fields, which this driver ignores. How often a frame carries pump
-    // state varies enormously - hundreds a day in some stretches, a handful in others - so the
-    // notification stream cannot be relied on to keep state current on its own. That is what the
-    // round trip is for.
 
-    /// The heartbeat door (`considerFullSync`), evaluated on every patch notification and running
-    /// the sync on a background queue. It is off the loop's critical path and therefore
-    /// effectively free, so it should be **eager**: refresh early, and the loop will find the
-    /// state already fresh when it asks.
+    /// background sync, doesn't lock loops
     static let heartbeatSyncFreshnessInterval: TimeInterval = .minutes(2.5)
 
-    /// The loop door (`ensureCurrentPumpData`), which the host calls and *blocks* on - and a
-    /// `SynchronizePacket` is a three-fragment response costing roughly 4s. So it should be
-    /// **lazy**: only force a sync if the heartbeat door has genuinely failed to do one.
-    ///
-    /// The trade-off in raising this: `syncPumpData` is also what calls `ensureConnectedAndActive`,
-    /// so this door doubles as a reconnect trigger. When the heartbeat door is not firing - link
-    /// down, or the patch gone quiet - recovery waits this long rather than the 2.5 minutes it
-    /// used to.
+    /// start of the loop, try to avoid syncs
     static let loopSyncFreshnessInterval: TimeInterval = .minutes(4.5)
 
-    /// Patch clock drift only feeds a settings badge (`shouldShowTimeWarning`) and nothing in the
-    /// dosing path, but `fetchPatchTime` is a second BLE round trip and used to run on every
-    /// single sync - a second command per sync, several hundred a day, to watch a value that
-    /// moves by seconds per day.
     static let patchTimeRefreshInterval: TimeInterval = .minutes(30)
 
     public required convenience init?(rawState: RawStateValue) {

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -42,6 +42,35 @@ public class MedtrumPumpManager: DeviceManager {
         bluetooth.pumpManager = self
     }
 
+    // There are two doors into the full `SynchronizePacket` round trip, and they deliberately
+    // hold *different* thresholds, because they cost completely different things.
+    //
+    // Both measure the age of `state.lastSync`, which only advances on a full sync or on a
+    // notification that actually changed something - so it tracks "when we last had a complete
+    // picture", and these thresholds are how long we are willing to go without one.
+    //
+    // The patch does notify frequently (measured at roughly one frame every 7s), but the great
+    // majority carry only CGM fields, which this driver ignores. How often a frame carries pump
+    // state varies enormously - hundreds a day in some stretches, a handful in others - so the
+    // notification stream cannot be relied on to keep state current on its own. That is what the
+    // round trip is for.
+
+    /// The heartbeat door (`considerFullSync`), evaluated on every patch notification and running
+    /// the sync on a background queue. It is off the loop's critical path and therefore
+    /// effectively free, so it should be **eager**: refresh early, and the loop will find the
+    /// state already fresh when it asks.
+    static let heartbeatSyncFreshnessInterval: TimeInterval = .minutes(2.5)
+
+    /// The loop door (`ensureCurrentPumpData`), which the host calls and *blocks* on - and a
+    /// `SynchronizePacket` is a three-fragment response costing roughly 4s. So it should be
+    /// **lazy**: only force a sync if the heartbeat door has genuinely failed to do one.
+    ///
+    /// The trade-off in raising this: `syncPumpData` is also what calls `ensureConnectedAndActive`,
+    /// so this door doubles as a reconnect trigger. When the heartbeat door is not firing - link
+    /// down, or the patch gone quiet - recovery waits this long rather than the 2.5 minutes it
+    /// used to.
+    static let loopSyncFreshnessInterval: TimeInterval = .minutes(4.5)
+
     /// Patch clock drift only feeds a settings badge (`shouldShowTimeWarning`) and nothing in the
     /// dosing path, but `fetchPatchTime` is a second BLE round trip and used to run on every
     /// single sync - a second command per sync, several hundred a day, to watch a value that
@@ -226,13 +255,15 @@ public extension MedtrumPumpManager {
     }
 
     func ensureCurrentPumpData(completion: ((Date?) -> Void)?) {
+        let age = Date.now.timeIntervalSince(state.lastSync)
+
         guard let activatedAt = state.patchActivatedAt,
-              Date.now.timeIntervalSince(state.lastSync) > .minutes(2.5) ||
+              age > Self.loopSyncFreshnessInterval ||
               Date.now.timeIntervalSince(activatedAt) < .minutes(4)
         else {
             log
                 .warning(
-                    "Skipping status update -> data is fresh or not active: \(Date.now.timeIntervalSince(state.lastSync)) sec"
+                    "Skipping status update -> data is fresh or not active: \(age) sec"
                 )
             completion?(nil)
             return

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -28,6 +28,13 @@ class PeripheralManager: NSObject {
 
     private let semaphore = DispatchSemaphore(value: 1)
 
+    /* access must be serialized with stateLock */
+    /// True while `considerFullSync` has a `SynchronizePacket` outstanding. That decision is made
+    /// on every patch notification - seconds apart - while a sync takes seconds to complete, and a
+    /// *failed* sync never advances `lastSync`. Without this, a bad link would start a fresh sync
+    /// on every notification and pile them up behind the write semaphore, ahead of real commands.
+    private var isFullSyncInFlight = false
+
     public init(
         _ peripheral: CBPeripheral,
         _ bluetoothManager: BluetoothManager,
@@ -277,12 +284,33 @@ extension PeripheralManager: CBPeripheralDelegate {
         }
 
         if characteristic.uuid == CBUUID.READ_UUID {
-            guard data[1] != 0x00 else {
+            // data[0] is the PatchState and data[1..3] the little-endian field mask, so data[1]
+            // is the low byte - suspend, bolus, basal, setup, reservoir, startTime, battery -
+            // and data[2] the high byte: storage, alarm, age, magneto placement.
+            //
+            // Only frames with something in the low byte are worth parsing. In practice that is
+            // the minority: the patch also reports CGM data on this characteristic, and those
+            // frames carry nothing this driver consumes.
+            if data[1] != 0x00 {
+                handleHeartbeat(data: data)
+            } else {
+                // Nothing in the low byte to apply, but the patch is alive and the host may be
+                // relying on us for its loop trigger. (The parsing path fires this too, at the
+                // end of `parseStateUpdate`.)
                 pumpManager.issueHeartbeatIfNeeded()
-                return
             }
 
-            handleHeartbeat(data: data)
+            // Last, and outside the branch, for two reasons.
+            //
+            // It has to see the payload's effects: applying a frame can advance `lastSync` or
+            // settle `bolusState`, so deciding first means starting a sync the frame had already
+            // made unnecessary, or skipping as "bolusing" a bolus that same frame just reported
+            // finished.
+            //
+            // And it has to run for unparsed frames too. The decision needs only the age of the
+            // last complete picture, never the payload, so confining it to parsed frames only
+            // starved it - the loop's own blocking sync would get there first.
+            considerFullSync()
             return
         }
 
@@ -377,21 +405,50 @@ extension PeripheralManager: CBPeripheralDelegate {
         var packet = NotificationPacket()
         packet.decode(data)
 
+        // Always apply what the patch just told us. `StateSyncer.sync` takes whatever fields the
+        // frame carried - basal state, reservoir, battery, suspend detection - and this is free,
+        // no round trip involved. It used to be skipped whenever a full sync was about to run,
+        // which threw away an update already in hand if that sync then failed.
+        parseStateUpdate(packet.parseResponse(), duringReconnect: false, fullSync: false)
+    }
+
+    /// Decides whether the patch's picture is stale enough to be worth a full `SynchronizePacket`,
+    /// and starts one if so.
+    ///
+    /// Deliberately takes no payload: the decision needs only the age of the last full sync, so it
+    /// can be made for *every* notification rather than only the ones that carry low-byte fields.
+    private func considerFullSync() {
         guard Date.now.timeIntervalSince(pumpManager.state.lastSync) > .minutes(2.5) else {
-            parseStateUpdate(packet.parseResponse(), duringReconnect: false, fullSync: false)
             return
         }
 
+        // An extra command in the middle of a bolus is not worth the risk; the bolus keeps
+        // pushing progress through the notification stream meanwhile. Logged at debug, not
+        // warning: this is evaluated on every notification, so at warning level a single bolus
+        // would fill the log with one line every few seconds.
         guard pumpManager.state.bolusState == .noBolus else {
-            parseStateUpdate(packet.parseResponse(), duringReconnect: false, fullSync: false)
-            log.warning("Skipping sync, pump is currently bolusing")
+            log.debug("Skipping sync, pump is currently bolusing")
             return
         }
 
-        // Do full sync (only every 3min)
+        stateLock.lock()
+        guard !isFullSyncInFlight else {
+            stateLock.unlock()
+            return
+        }
+        isFullSyncInFlight = true
+        stateLock.unlock()
+
+        // Do the full sync off the loop's critical path.
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            // If self is gone the flag went with it, so there is nothing to release.
             guard let self else {
                 return
+            }
+            defer {
+                self.stateLock.lock()
+                self.isFullSyncInFlight = false
+                self.stateLock.unlock()
             }
 
             let response = self.writePacket(SynchronizePacket())

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -28,11 +28,7 @@ class PeripheralManager: NSObject {
 
     private let semaphore = DispatchSemaphore(value: 1)
 
-    /* access must be serialized with stateLock */
-    /// True while `considerFullSync` has a `SynchronizePacket` outstanding. That decision is made
-    /// on every patch notification - seconds apart - while a sync takes seconds to complete, and a
-    /// *failed* sync never advances `lastSync`. Without this, a bad link would start a fresh sync
-    /// on every notification and pile them up behind the write semaphore, ahead of real commands.
+    /* access must be serialized with stateLock, prevents concurrent `considerFullSync` runs */
     private var isFullSyncInFlight = false
 
     public init(
@@ -284,32 +280,13 @@ extension PeripheralManager: CBPeripheralDelegate {
         }
 
         if characteristic.uuid == CBUUID.READ_UUID {
-            // data[0] is the PatchState and data[1..3] the little-endian field mask, so data[1]
-            // is the low byte - suspend, bolus, basal, setup, reservoir, startTime, battery -
-            // and data[2] the high byte: storage, alarm, age, magneto placement.
-            //
-            // Only frames with something in the low byte are worth parsing. In practice that is
-            // the minority: the patch also reports CGM data on this characteristic, and those
-            // frames carry nothing this driver consumes.
+            // data[1] == 0x00, is a heartbeat with  no data
             if data[1] != 0x00 {
                 handleHeartbeat(data: data)
             } else {
-                // Nothing in the low byte to apply, but the patch is alive and the host may be
-                // relying on us for its loop trigger. (The parsing path fires this too, at the
-                // end of `parseStateUpdate`.)
                 pumpManager.issueHeartbeatIfNeeded()
             }
 
-            // Last, and outside the branch, for two reasons.
-            //
-            // It has to see the payload's effects: applying a frame can advance `lastSync` or
-            // settle `bolusState`, so deciding first means starting a sync the frame had already
-            // made unnecessary, or skipping as "bolusing" a bolus that same frame just reported
-            // finished.
-            //
-            // And it has to run for unparsed frames too. The decision needs only the age of the
-            // last complete picture, never the payload, so confining it to parsed frames only
-            // starved it - the loop's own blocking sync would get there first.
             considerFullSync()
             return
         }
@@ -405,28 +382,15 @@ extension PeripheralManager: CBPeripheralDelegate {
         var packet = NotificationPacket()
         packet.decode(data)
 
-        // Always apply what the patch just told us. `StateSyncer.sync` takes whatever fields the
-        // frame carried - basal state, reservoir, battery, suspend detection - and this is free,
-        // no round trip involved. It used to be skipped whenever a full sync was about to run,
-        // which threw away an update already in hand if that sync then failed.
         parseStateUpdate(packet.parseResponse(), duringReconnect: false, fullSync: false)
     }
 
-    /// Decides whether the patch's picture is stale enough to be worth a full `SynchronizePacket`,
-    /// and starts one if so.
-    ///
-    /// Deliberately takes no payload: the decision needs only the age of the last full sync, so it
-    /// can be made for *every* notification rather than only the ones that carry low-byte fields.
     private func considerFullSync() {
         let age = Date.now.timeIntervalSince(pumpManager.state.lastSync)
         guard age > MedtrumPumpManager.heartbeatSyncFreshnessInterval else {
             return
         }
 
-        // An extra command in the middle of a bolus is not worth the risk; the bolus keeps
-        // pushing progress through the notification stream meanwhile. Logged at debug, not
-        // warning: this is evaluated on every notification, so at warning level a single bolus
-        // would fill the log with one line every few seconds.
         guard pumpManager.state.bolusState == .noBolus else {
             log.debug("Skipping sync, pump is currently bolusing")
             return
@@ -442,7 +406,6 @@ extension PeripheralManager: CBPeripheralDelegate {
 
         // Do the full sync off the loop's critical path.
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            // If self is gone the flag went with it, so there is nothing to release.
             guard let self else {
                 return
             }

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -280,7 +280,7 @@ extension PeripheralManager: CBPeripheralDelegate {
         }
 
         if characteristic.uuid == CBUUID.READ_UUID {
-            // data[1] == 0x00, is a heartbeat with  no data
+            // data[1] == 0x00, is a heartbeat with no data
             if data[1] != 0x00 {
                 handleHeartbeat(data: data)
             } else {

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -418,7 +418,8 @@ extension PeripheralManager: CBPeripheralDelegate {
     /// Deliberately takes no payload: the decision needs only the age of the last full sync, so it
     /// can be made for *every* notification rather than only the ones that carry low-byte fields.
     private func considerFullSync() {
-        guard Date.now.timeIntervalSince(pumpManager.state.lastSync) > .minutes(2.5) else {
+        let age = Date.now.timeIntervalSince(pumpManager.state.lastSync)
+        guard age > MedtrumPumpManager.heartbeatSyncFreshnessInterval else {
             return
         }
 

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -407,7 +407,7 @@ extension PeripheralManager: CBPeripheralDelegate {
                 }
 
                 self.parseStateUpdate(syncResponse, duringReconnect: false, fullSync: true)
-                StateSyncer.fetchPatchTime(pumpManager: self.pumpManager)
+                StateSyncer.fetchPatchTimeIfStale(pumpManager: self.pumpManager)
             }
         }
     }

--- a/MedtrumKit/PumpManager/StateSyncer.swift
+++ b/MedtrumKit/PumpManager/StateSyncer.swift
@@ -139,12 +139,6 @@ enum StateSyncer {
         pumpManager.notifyStateDidChange()
     }
 
-    /// Reads the patch clock only if the last reading has aged out.
-    ///
-    /// `fetchPatchTime` is a full BLE round trip and it ran on every sync, doubling the number of
-    /// commands the sync path issues. What it feeds - `shouldShowTimeWarning()` - is a settings
-    /// badge with a 15-second tolerance and no influence on dosing, and a patch clock drifts by
-    /// seconds per day, so checking it every few minutes buys nothing.
     public static func fetchPatchTimeIfStale(pumpManager: MedtrumPumpManager) {
         let age = Date.now.timeIntervalSince(pumpManager.state.pumpTimeSyncedAt)
         guard age > MedtrumPumpManager.patchTimeRefreshInterval else {

--- a/MedtrumKit/PumpManager/StateSyncer.swift
+++ b/MedtrumKit/PumpManager/StateSyncer.swift
@@ -139,6 +139,21 @@ enum StateSyncer {
         pumpManager.notifyStateDidChange()
     }
 
+    /// Reads the patch clock only if the last reading has aged out.
+    ///
+    /// `fetchPatchTime` is a full BLE round trip and it ran on every sync, doubling the number of
+    /// commands the sync path issues. What it feeds - `shouldShowTimeWarning()` - is a settings
+    /// badge with a 15-second tolerance and no influence on dosing, and a patch clock drifts by
+    /// seconds per day, so checking it every few minutes buys nothing.
+    public static func fetchPatchTimeIfStale(pumpManager: MedtrumPumpManager) {
+        let age = Date.now.timeIntervalSince(pumpManager.state.pumpTimeSyncedAt)
+        guard age > MedtrumPumpManager.patchTimeRefreshInterval else {
+            return
+        }
+
+        fetchPatchTime(pumpManager: pumpManager)
+    }
+
     public static func fetchPatchTime(pumpManager: MedtrumPumpManager) {
         let timeData = pumpManager.bluetooth.write(GetTimePacket())
 


### PR DESCRIPTION
These changes came out of investigating this issue: https://github.com/jbr7rr/MedtrumKit/issues/186

Implementation was assisted by claude.

Needs more testing, more reviewing, and a go/no-go decision.
(I am testing this on my phone since ~1hr ago - no issues so far)

`/cc` @bastiaanv @mountrcg

3 changes to reduce loop duration:
* less frequent patch clock re-reads (every 30 minutes) (saves one 1-second roundtrip);
* run pump sync off of ping ("empty") packets - when the loop requests a sync, it should be fresh enough in most cases - previously this was only happening on non-empty packets;
* increase the freshness threshold for loop-initiated state sync to 4.5 minutes (background syncs will be happening every 2-3 minutes, and loops happen every ~5 minutes - this will prevent unnecessary syncs at the start of the loop - saving ~4 seconds of BLE comms)

---

Below is the summary by claude:

**1. Only re-read the patch clock every 30 minutes**

`fetchPatchTime` ran after every sync — 298 of 301 `GET_TIME` commands in a day's log
immediately followed a `SYNCHRONIZE`. It feeds `shouldShowTimeWarning()`, a settings badge
with a 15-second tolerance and no path into dosing, against a clock that drifts by seconds
per day. On the blocking loop path it was a full extra round trip. The explicit time sync
after `SetTimeZonePacket` still reads it unconditionally.

**2. Decide on a full sync from every patch notification**

The freshness check lived inside `handleHeartbeat`, which only runs for frames whose field
mask has a non-empty low byte. The patch also streams CGM frames on the same characteristic,
and those dominate — one 40-minute window had **306 of 307 notifications skip the parse**. So
the door was reachable a few times an hour while the loop asked every five minutes, and the
loop's blocking sync kept winning the race.

The decision needs only the age of the last complete picture, never the payload, so it moves
out to `considerFullSync()` and runs on every notification. It runs *after* the payload is
applied, since a frame can advance `lastSync` or settle `bolusState`. `isFullSyncInFlight`
bounds it to one outstanding sync — a failed sync never advances `lastSync`, so without it a
bad link would queue a sync per notification ahead of real commands.

`handleHeartbeat` now does one thing: apply the frame. It previously discarded the payload on
the path where it was about to full-sync, losing an update already in hand if that sync failed.

**3. Separate freshness thresholds for the two doors**

Both held 2.5 minutes despite costing completely different things. Now: background door eager
at 2.5 min, blocking door lazy at 4.5 min.

#### Measured effect

| | before | after |
|---|---|---|
| `ensureCurrentPumpData` (the call the loop blocks on) | ~4000 ms | **~8 ms** |
| syncs via the blocking door | 5 of 5 | **0 of 10** |
| `GET_TIME` round trips | ~300/day | ~48/day |

For scale, on this link a `SYNCHRONIZE` is a three-fragment response costing ~4 s, and
single-fragment commands cost ~1.26 s — each fragment is roughly one BLE connection interval.

### Relation to #186 (background CPU throttling)

**The throttling is real.** Backgrounded compute runs 6–23× slower than foreground on the same
build, same cycle, same QoS — `determineBasal` 89 ms → 616 ms, `js.profile` 2.1 ms → 47.9 ms.
BLE round trips beside it are flat (`GET_TIME` 1255.8 ms → 1258.9 ms, **1.00×**), which is what
makes the compute numbers credible rather than an artifact.

**But the proposed fix targets a mechanism I couldn't find.** Components A and B rest on iOS
granting a fast window just after a scheduled wake. A fixed-work CPU probe placed at the very
first line of the CGM delegate callback — +0 s into the wake — measured **18.1 ms**, against
16.3–18.9 ms at every later point in the same cycle. No fast window, so no benefit from waking
at a better moment. QoS was also ruled out: every probe ran at `userInitiated` in both phases.
The suspension probe never overslept.

**And on this device the throttling isn't the dominant cost.** End to end, reading → enacted is
~10.5 s, of which ~7 s is BLE round trips that don't move with app phase at all. The throttling
is worth ~2 s. This PR removes ~4 s.
