### PR TITLE
repeated auto reconnect + safer session handling

### DIFF
--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -72,12 +72,18 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
             scanCompletion = nil
         }
 
-        logger.info("Connecting to \(peripheral)")
-
         // cancelling a pending connect does not always produce a didDisconnect
         forcedDisconnect = false
 
         self.peripheral = peripheral
+
+        // a connect from an earlier attempt can still be pending
+        guard peripheral.state != .connecting else {
+            logger.info("Connect already pending, waiting on it")
+            return
+        }
+
+        logger.info("Connecting to \(peripheral)")
         manager.connect(peripheral)
     }
 
@@ -292,6 +298,8 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
     private func armTimeout(_ attempt: ConnectAttempt, seconds: TimeInterval) {
         attempt.timeout?.cancel()
         attempt.armedAt = .now
+        attempt.timeoutGeneration &+= 1
+        let generation = attempt.timeoutGeneration
 
         attempt.timeout = Task { [weak self, weak attempt] in
             do {
@@ -307,7 +315,9 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
 
             managerQueue.async { [weak self, weak attempt] in
                 // is this still the attempt in flight? Covers being superseded by a re-arm, and waking a moment before cancellation landed.
-                guard let self, let attempt, self.attempt === attempt else {
+                guard let self, let attempt, self.attempt === attempt,
+                      attempt.timeoutGeneration == generation
+                else {
                     return
                 }
 

--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -16,6 +16,9 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
 
     private var attempt: ConnectAttempt?
 
+    private var reconnectAttempts = 0
+    private var reconnectTask: Task<Void, Never>?
+
     // MUST NOT be called from within managerQueue - deadlock
     public var isConnected: Bool {
         managerQueue.sync { isConnectedOnQueue }
@@ -70,6 +73,9 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
 
         logger.info("Connecting to \(peripheral)")
 
+        // cancelling a pending connect does not always produce a didDisconnect
+        forcedDisconnect = false
+
         self.peripheral = peripheral
         manager.connect(peripheral)
     }
@@ -95,8 +101,61 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
             self.attempt = nil
         }
 
+        if error == nil {
+            reconnectAttempts = 0
+            reconnectTask?.cancel()
+            reconnectTask = nil
+        } else {
+            scheduleReconnect()
+        }
+
         for completion in attempt.completions {
             report(error, to: completion)
+        }
+    }
+
+    /// Must be called on `managerQueue`.
+    private func scheduleReconnect() {
+        // `ensureConnectedOnQueue` can retrieve the peripheral from stored identifier
+        guard peripheral != nil || pumpManager?.state.peripheralIdentifier != nil else {
+            // otherwise we would be retrying a scan, which doesn't work in the background
+            return
+        }
+
+        let seconds: TimeInterval = reconnectAttempts == 0
+            ? 0
+            : min(TimeInterval(1 << min(reconnectAttempts, 6)), 60)
+        reconnectAttempts += 1
+
+        logger.info("Scheduling reconnect #\(reconnectAttempts) in \(Int(seconds))s")
+
+        reconnectTask?.cancel()
+        reconnectTask = Task { [weak self] in
+            if seconds > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(seconds) * 1_000_000_000)
+                if Task.isCancelled {
+                    return
+                }
+            }
+
+            guard let self else {
+                return
+            }
+
+            managerQueue.async {
+                guard self.attempt == nil,
+                      !self.isConnectedOnQueue,
+                      self.peripheral != nil || self.pumpManager?.state.peripheralIdentifier != nil
+                else {
+                    return
+                }
+
+                self.ensureConnectedOnQueue { error in
+                    if let error = error {
+                        self.logger.warning("Failed to auto-reconnect: \(error)")
+                    }
+                }
+            }
         }
     }
 
@@ -269,7 +328,8 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
     private func disconnectOnQueue(force: Bool) {
         forcedDisconnect = force
 
-        if let peripheral, peripheral.state == .connected {
+        // both .connected AND .connecting
+        if let peripheral, peripheral.state != .disconnected {
             manager.cancelPeripheralConnection(peripheral)
         }
 
@@ -288,13 +348,30 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
     }
 
     private func clearPeripheralOnQueue() {
+        if manager.isScanning {
+            manager.stopScan()
+        }
+        scanCompletion = nil
+
         peripheral = nil
+        // didDisconnectPeripheral returns early on a forced disconnect, so this is the only place
+        // the forced path can invalidate the manager - releasing it is not enough, its auth/sync
+        // worker holds its own reference and would keep writing to pumpManager.state.
+        peripheralManager?.cleanup()
         peripheralManager = nil
 
         if pumpManager?.state.peripheralIdentifier != nil {
             pumpManager?.state.peripheralIdentifier = nil
             pumpManager?.notifyStateDidChange()
         }
+
+        if let attempt = attempt {
+            finish(attempt, .failedToFindDevice)
+        }
+
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        reconnectAttempts = 0
     }
 }
 
@@ -389,8 +466,14 @@ extension BluetoothManager {
         )
     }
 
-    func centralManager(_: CBCentralManager, didConnect peripheral: CBPeripheral) {
+    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
         logger.info("Connected to pump: \(peripheral.name ?? "<NO_NAME>")!")
+
+        if forcedDisconnect {
+            logger.info("Dropping a connection that landed after a forced disconnect")
+            central.cancelPeripheralConnection(peripheral)
+            return
+        }
 
         // This guard drops the link rather than just returning. `peripheral` is already set at this
         // point, so bailing out would leave a live peripheral with no PeripheralManager behind it:
@@ -488,14 +571,10 @@ extension BluetoothManager {
         }
 
         if let attempt = attempt {
+            logger.info("Disconnected during the connect sequence")
             finish(attempt, .failedToConnectToDevice)
-
         } else {
-            ensureConnectedOnQueue { error in
-                if let error = error {
-                    self.logger.warning("Failed to auto-reconnect: \(error)")
-                }
-            }
+            scheduleReconnect()
         }
     }
 

--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -477,31 +477,26 @@ extension BluetoothManager {
             return
         }
 
-        let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data
-        guard let manufacturerData, manufacturerData.count >= 8 else {
-            #if targetEnvironment(simulator)
-                // Simulator bypass -> 200u
-                scanCompletion?(
-                    .success(
-                        peripheral: peripheral,
-                        pumpSN: Data([0x28, 0xD8, 0x12, 0x4A]),
-                        deviceType: 1,
-                        version: 1
-                    )
+        let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey]
+        guard let manufacturerData = manufacturerData as? Data, manufacturerData.count >= 7 else {
+            // Simulator bypass -> 200u
+            scanCompletion?(
+                .success(
+                    peripheral: peripheral,
+                    pumpSN: Data([0x28, 0xD8, 0x12, 0x4A]),
+                    deviceType: 1,
+                    version: 1
                 )
-                // Simulator bypass -> 300u
-                scanCompletion?(
-                    .success(
-                        peripheral: peripheral,
-                        pumpSN: Data([0x14, 0x16, 0xDF, 0x52]),
-                        deviceType: 1,
-                        version: 1
-                    )
+            )
+            // Simulator bypass -> 300u
+            scanCompletion?(
+                .success(
+                    peripheral: peripheral,
+                    pumpSN: Data([0x14, 0x16, 0xDF, 0x52]),
+                    deviceType: 1,
+                    version: 1
                 )
-            #else
-                // On device this is some other peripheral calling itself MT, not a pump.
-                logger.debug("Ignoring MT advertisement with \(manufacturerData?.count ?? 0) bytes of manufacturer data")
-            #endif
+            )
             return
         }
 

--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -24,8 +24,9 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
         managerQueue.sync { isConnectedOnQueue }
     }
 
+    /// a live link alone is not yet a usable session
     private var isConnectedOnQueue: Bool {
-        if let peripheral = peripheral, peripheral.state == .connected {
+        if let peripheral = peripheral, peripheral.state == .connected, peripheralManager?.isReady == true {
             return true
         }
 
@@ -80,6 +81,22 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
         manager.connect(peripheral)
     }
 
+    /// anything that mutates connection state must check this.
+    private func isCurrent(_ candidate: CBPeripheral) -> Bool {
+        candidate.identifier == peripheral?.identifier
+    }
+
+    /// Disconnects only if `manager` is still the one driving the link
+    func disconnect(ifCurrent candidate: PeripheralManager) {
+        managerQueue.async {
+            guard self.peripheralManager === candidate else {
+                return
+            }
+
+            self.disconnectOnQueue(force: false)
+        }
+    }
+
     /// Hands a result to a caller. Never on the current thread: completions issue blocking BLE
     /// writes: from the main thread that freezes the UI for up to 30s per packet (syncPumpTime
     /// sends three), and from managerQueue - which every caller of this is now on - it would
@@ -105,6 +122,7 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
             reconnectAttempts = 0
             reconnectTask?.cancel()
             reconnectTask = nil
+            rememberPeripheral()
         } else {
             scheduleReconnect()
         }
@@ -112,6 +130,15 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
         for completion in attempt.completions {
             report(error, to: completion)
         }
+    }
+
+    private func rememberPeripheral() {
+        guard let pumpManager, let peripheral, pumpManager.state.peripheralIdentifier != peripheral.identifier else {
+            return
+        }
+
+        pumpManager.state.peripheralIdentifier = peripheral.identifier
+        pumpManager.notifyStateDidChange()
     }
 
     /// Must be called on `managerQueue`.
@@ -179,9 +206,16 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
         let attempt = ConnectAttempt(completion)
         self.attempt = attempt
 
-        if let peripheral = peripheral, peripheral.state == .connected {
+        if isConnectedOnQueue {
             logger.debug("Already connect!")
             finish(attempt, nil)
+            return
+        }
+
+        if let peripheral = peripheral, peripheral.state == .connected {
+            logger.warning("Connected but the session is not ready, dropping the link to rebuild it")
+            startTimeout(attempt, seconds: .seconds(15))
+            manager.cancelPeripheralConnection(peripheral)
             return
         }
 
@@ -326,7 +360,10 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
     }
 
     private func disconnectOnQueue(force: Bool) {
-        forcedDisconnect = force
+        // forcedDisconnect is set to true only here, normal disconnects should not abort the force disconnect
+        if force {
+            forcedDisconnect = true
+        }
 
         // both .connected AND .connecting
         if let peripheral, peripheral.state != .disconnected {
@@ -352,6 +389,8 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
             manager.stopScan()
         }
         scanCompletion = nil
+
+        pumpManager?.state.isConnected = false
 
         peripheral = nil
         // didDisconnectPeripheral returns early on a forced disconnect, so this is the only place
@@ -428,26 +467,31 @@ extension BluetoothManager {
             return
         }
 
-        let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey]
-        guard let manufacturerData = manufacturerData as? Data, manufacturerData.count >= 7 else {
-            // Simulator bypass -> 200u
-            scanCompletion?(
-                .success(
-                    peripheral: peripheral,
-                    pumpSN: Data([0x28, 0xD8, 0x12, 0x4A]),
-                    deviceType: 1,
-                    version: 1
+        let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data
+        guard let manufacturerData, manufacturerData.count >= 8 else {
+            #if targetEnvironment(simulator)
+                // Simulator bypass -> 200u
+                scanCompletion?(
+                    .success(
+                        peripheral: peripheral,
+                        pumpSN: Data([0x28, 0xD8, 0x12, 0x4A]),
+                        deviceType: 1,
+                        version: 1
+                    )
                 )
-            )
-            // Simulator bypass -> 300u
-            scanCompletion?(
-                .success(
-                    peripheral: peripheral,
-                    pumpSN: Data([0x14, 0x16, 0xDF, 0x52]),
-                    deviceType: 1,
-                    version: 1
+                // Simulator bypass -> 300u
+                scanCompletion?(
+                    .success(
+                        peripheral: peripheral,
+                        pumpSN: Data([0x14, 0x16, 0xDF, 0x52]),
+                        deviceType: 1,
+                        version: 1
+                    )
                 )
-            )
+            #else
+                // On device this is some other peripheral calling itself MT, not a pump.
+                logger.debug("Ignoring MT advertisement with \(manufacturerData?.count ?? 0) bytes of manufacturer data")
+            #endif
             return
         }
 
@@ -472,6 +516,19 @@ extension BluetoothManager {
         if forcedDisconnect {
             logger.info("Dropping a connection that landed after a forced disconnect")
             central.cancelPeripheralConnection(peripheral)
+            return
+        }
+
+        guard isCurrent(peripheral) else {
+            logger.info("Dropping a connection for a peripheral we are not driving")
+            central.cancelPeripheralConnection(peripheral)
+            return
+        }
+
+        // A real reconnect passes through didDisconnect first, which cleans the manager up - so a
+        // ready session here means this callback is a duplicate.
+        if peripheralManager?.isReady == true {
+            logger.info("Ignoring duplicate didConnect - session already established")
             return
         }
 
@@ -509,13 +566,8 @@ extension BluetoothManager {
         forcedDisconnect = false
 
         self.peripheral = peripheral
-        // Remember what to reconnect to. Only identifiers that actually produced a connection get
-        // stored, and it survives an app restart, so the scan path is only ever needed for pairing.
-        if pumpManager.state.peripheralIdentifier != peripheral.identifier {
-            pumpManager.state.peripheralIdentifier = peripheral.identifier
-            pumpManager.notifyStateDidChange()
-        }
 
+        peripheralManager?.cleanup()
         peripheralManager = PeripheralManager(peripheral, self, pumpManager) { [weak self] error in
             // Called from two queues: the CBPeripheralDelegate callbacks report discovery failures
             // on managerQueue, while the auth flow runs on a global worker and reports from there.
@@ -555,6 +607,11 @@ extension BluetoothManager {
                 "Device disconnected, name: \(peripheral.name ?? "<NO_NAME>"), error: \(error?.localizedDescription ?? "No error")"
             )
 
+        guard isCurrent(peripheral) else {
+            logger.info("Ignoring disconnect for a peripheral we are not driving")
+            return
+        }
+
         if forcedDisconnect {
             forcedDisconnect = false
             return
@@ -583,6 +640,11 @@ extension BluetoothManager {
             .info(
                 "Device connect error, name: \(peripheral.name ?? "<NO_NAME>"), error: \(error?.localizedDescription ?? "No error")"
             )
+
+        guard isCurrent(peripheral) else {
+            logger.info("Ignoring connect error for a peripheral we are not driving")
+            return
+        }
 
         if let pumpManager = self.pumpManager {
             pumpManager.state.isConnected = false

--- a/MedtrumKit/PumpManager/ConnectAttempt.swift
+++ b/MedtrumKit/PumpManager/ConnectAttempt.swift
@@ -12,6 +12,7 @@ import Foundation
 final class ConnectAttempt {
     private(set) var completions: [(MedtrumConnectError?) -> Void]
     var timeout: Task<Void, Never>?
+    var timeoutGeneration = 0
     private var reported = false
 
     /// When the deadline currently in flight was armed. `Task.sleep` does not advance while iOS has

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -884,6 +884,8 @@ public extension MedtrumPumpManager {
         notifyStateDidChange()
 
         emitPumpEvents(events)
+
+        bluetooth.disconnect(force: true)
     }
 
     func clearAlert(alertType: AlertType, completion: @escaping (Bool) -> Void) {

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -234,10 +234,7 @@ public extension MedtrumPumpManager {
               age > Self.loopSyncFreshnessInterval ||
               Date.now.timeIntervalSince(activatedAt) < .minutes(4)
         else {
-            log
-                .warning(
-                    "Skipping status update -> data is fresh or not active: \(age) sec"
-                )
+            log.info("Skipping status update -> data is fresh or not active: \(Int(age)) sec")
             completion?(nil)
             return
         }

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -24,6 +24,7 @@ class PeripheralManager: NSObject {
     private var currentSequence: UInt8 = 0
     private var writeQueue: MedtrumKitDispatchGroup?
     private var writeResponse: MedtrumWriteResult<Any>?
+    private var isInvalidated = false
     /* end */
 
     private let semaphore = DispatchSemaphore(value: 1)
@@ -49,6 +50,7 @@ class PeripheralManager: NSObject {
 
     func cleanup() {
         stateLock.lock()
+        isInvalidated = true
         let queue = writeQueue
         writeQueue = nil
         currentPacket = nil
@@ -57,6 +59,12 @@ class PeripheralManager: NSObject {
         // outside the lock: leave() takes a lock of its own, and it wakes writePacket, which
         // immediately wants ours.
         queue?.leave()
+    }
+
+    private var isInvalidatedLocked: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return isInvalidated
     }
 
     func writePacket(_ packet: any MedtrumBasePacketProtocol) -> MedtrumWriteResult<Any> {
@@ -74,6 +82,13 @@ class PeripheralManager: NSObject {
         writeQ.enter()
 
         stateLock.lock()
+        guard !isInvalidated else {
+            stateLock.unlock()
+            // Balance the enter above: the group has to be entered before it is published, or
+            // cleanup could leave() it first and this write would then wait out its full timeout.
+            writeQ.leave()
+            return .failure(error: .noManager)
+        }
         writeQueue = writeQ
         currentPacket = packet
         currentSequence = writeSequence
@@ -178,6 +193,10 @@ extension PeripheralManager {
             completion?(.failedToCompleteAuthorizationFlow(localizedError: error.localizedDescription))
 
         case .success:
+            guard !isInvalidatedLocked else {
+                return
+            }
+
             log.info("Connected to pump!")
 
             pumpManager.state.isConnected = true
@@ -187,6 +206,10 @@ extension PeripheralManager {
     }
 
     private func parseStateUpdate(_ syncResponse: SynchronizePacketResponse, duringReconnect: Bool, fullSync: Bool) {
+        guard !isInvalidatedLocked else {
+            return
+        }
+
         // TEMP
         do {
             log.info("State update: \(String(data: try JSONEncoder().encode(syncResponse), encoding: .utf8) ?? "")")

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -25,6 +25,7 @@ class PeripheralManager: NSObject {
     private var writeQueue: MedtrumKitDispatchGroup?
     private var writeResponse: MedtrumWriteResult<Any>?
     private var isInvalidated = false
+    private var isReadyStorage = false
     /* end */
 
     private let semaphore = DispatchSemaphore(value: 1)
@@ -59,6 +60,16 @@ class PeripheralManager: NSObject {
         // outside the lock: leave() takes a lock of its own, and it wakes writePacket, which
         // immediately wants ours.
         queue?.leave()
+    }
+
+    private func disconnectIfActive() {
+        bluetoothManager.disconnect(ifCurrent: self)
+    }
+
+    var isReady: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return isReadyStorage
     }
 
     private var isInvalidatedLocked: Bool {
@@ -143,12 +154,13 @@ extension PeripheralManager {
             }
 
             log.error("Failed to complete authorization flow: \(error.localizedDescription)")
-            bluetoothManager.disconnect()
+            disconnectIfActive()
             completion?(.failedToCompleteAuthorizationFlow(localizedError: error.localizedDescription))
 
         case let .success(data):
             guard let authResponse = data as? AuthorizeResponse else {
                 log.error("Failed to complete authorization flow: invalid response")
+                disconnectIfActive()
                 completion?(.failedToCompleteAuthorizationFlow(localizedError: "invalid response"))
                 return
             }
@@ -167,12 +179,13 @@ extension PeripheralManager {
         switch syncData {
         case let .failure(error):
             log.error("Failed to synchronize: \(error.localizedDescription)")
-            bluetoothManager.disconnect()
+            disconnectIfActive()
             completion?(.failedToCompleteAuthorizationFlow(localizedError: error.localizedDescription))
 
         case let .success(data):
             guard let syncResponse = data as? SynchronizePacketResponse else {
                 log.error("Failed to Synchronize packet: invalid response")
+                disconnectIfActive()
                 completion?(.failedToCompleteAuthorizationFlow(localizedError: "invalid response"))
                 return
             }
@@ -189,7 +202,7 @@ extension PeripheralManager {
         switch subscribeData {
         case let .failure(error):
             log.error("Failed to subscribe: \(error.localizedDescription)")
-            bluetoothManager.disconnect()
+            disconnectIfActive()
             completion?(.failedToCompleteAuthorizationFlow(localizedError: error.localizedDescription))
 
         case .success:
@@ -198,6 +211,10 @@ extension PeripheralManager {
             }
 
             log.info("Connected to pump!")
+
+            stateLock.lock()
+            isReadyStorage = true
+            stateLock.unlock()
 
             pumpManager.state.isConnected = true
             pumpManager.notifyStateDidChange()
@@ -233,6 +250,7 @@ extension PeripheralManager: CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
         if let error = error {
             log.error("\(error.localizedDescription)")
+            disconnectIfActive()
             completion?(.failedToDiscoverServices(localizedError: error.localizedDescription))
             return
         }
@@ -242,6 +260,7 @@ extension PeripheralManager: CBPeripheralDelegate {
             let localizedError = "No Medtrum service found - " +
                 (peripheral.services?.map(\.uuid.uuidString).joined(separator: ", ") ?? "No services discovered")
             log.error(localizedError)
+            disconnectIfActive()
             completion?(.failedToDiscoverServices(localizedError: localizedError))
             return
         }
@@ -252,6 +271,7 @@ extension PeripheralManager: CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
         if let error = error {
             log.error("\(error.localizedDescription)")
+            disconnectIfActive()
             completion?(.failedToDiscoverCharacteristics(localizedError: error.localizedDescription))
             return
         }
@@ -264,6 +284,7 @@ extension PeripheralManager: CBPeripheralDelegate {
                 (service.characteristics?.map(\.uuid.uuidString).joined(separator: ", ") ?? "No characteristics discovered")
 
             log.error(localizedError)
+            disconnectIfActive()
             completion?(.failedToDiscoverCharacteristics(localizedError: localizedError))
             return
         }


### PR DESCRIPTION
- repeated automatic reconnect with bounded exponential backoff
- restore known peripherals by persisted `CoreBluetooth` identifier
- distinguishe a live BLE link from a fully authenticated and subscribed session
- clean up failed or superseded sessions without disrupting newer connections
- handle forced teardown, late callbacks, and malformed advertisements safely

---

Scanning remains limited to the foreground pairing flow. Background reconnects are attempted only when a peripheral reference or persisted identifier is available.

---

## Testing

Tested on device (iPhone, Medtrum Nano 200U, iAPS). Two scenarios, ~15 minutes.

<details>
  <summary>log analysis by claude</summary>


### 1. Force-quit and relaunch

Four launches. All reconnected in 1–3 s. One took the state-restoration path, which nothing
had previously exercised:

```
17:32:39  centralManagerDidUpdateState: 5
17:32:39  Reconnecting to restored state...
17:32:39  Connected to pump: MT!
17:32:52  subscribe(): Connected to pump!
17:32:52  Restored state!
```

No `Connected but the session is not ready` — the readiness gate never wrongly rejected a
usable session.

### 2. Phone in a fridge for 6 minutes, then locked for 3 more

Six disconnects, six recoveries. Recovery median 10 s, max 107 s.

**10 `Connecting to` and exactly 10 `didConnect`.** Before this PR the same situation produced
4 connects against 2 `didConnect`s (in Robert's logs), with two arriving together and the setup flow running twice
(see the 08:16:44 sequence in @mountrcg's logs). No stacking, no duplicates.

The suspension case fired twice, which is the harder half of the race:

```
17:37:06  Scheduling reconnect #1 in 0s → Connecting to …
17:37:52  Timeout woke after 46s of a 15s budget - app was suspended, re-arming
17:37:52  Connected to pump: MT!            ← same second
```

and again with a **106 s** oversleep at 17:39:43. `Task.sleep` is frozen while iOS suspends the
app, so the deadline woke long past its budget at the exact instant the connection landed. The
attempt was extended rather than failed, so the pending connect was never abandoned — and the
timeout-generation token stopped the stale deadline from failing a session that had just
connected. No spurious failures either time.

### One failed loop cycle, behaving correctly

```
17:36:02  enactTempBasal → Already connect!
17:36:15  Device disconnected
17:36:15  writePacket: Timeout has been reached...
17:36:15  Loop failed with error: Pump...
```

A temp basal was in flight when the link dropped. It failed in the same second rather than
sitting out its 30 s write timeout — `cleanup()` wakes the blocked write on disconnect. The next
cycle (17:40:57) enacted normally. One failed cycle out of three during a deliberate six-minute
blackout.

### Not yet exercised

- `Connect already pending, waiting on it` — the guard never fired here, because the oversleep
  extension meant no connect was ever actually abandoned. Reproducing it needs an outage with
  the phone awake.
- Force-deactivate → re-pair. Needs a patch change.

  
</details>