### PR TITLE
do not retain a cycle of strong references preventing CentralManager from deallocating

### DIFF
--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -1,7 +1,7 @@
 import CoreBluetooth
 
 class BluetoothManager: NSObject, CBCentralManagerDelegate {
-    public var pumpManager: MedtrumPumpManager?
+    public weak var pumpManager: MedtrumPumpManager?
 
     let logger = MedtrumLogger(category: "BluetoothManager")
 
@@ -31,6 +31,10 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
         }
 
         return false
+    }
+
+    deinit {
+        logger.info("BluetoothManager deallocated")
     }
 
     override init() {
@@ -133,7 +137,7 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
             scheduleReconnect()
         }
 
-        for completion in attempt.completions {
+        for completion in attempt.takeCompletions() {
             report(error, to: completion)
         }
     }
@@ -573,12 +577,16 @@ extension BluetoothManager {
         self.peripheral = peripheral
 
         peripheralManager?.cleanup()
-        peripheralManager = PeripheralManager(peripheral, self, pumpManager) { [weak self] error in
+        peripheralManager = PeripheralManager(peripheral, self, pumpManager) { [weak self, weak attempt] error in
             // Called from two queues: the CBPeripheralDelegate callbacks report discovery failures
             // on managerQueue, while the auth flow runs on a global worker and reports from there.
             // Land both on managerQueue, since that is where finish reads and clears the attempt.
             self?.managerQueue.async {
-                self?.finish(attempt, error)
+                guard let self, let attempt else {
+                    return
+                }
+
+                self.finish(attempt, error)
             }
         }
 

--- a/MedtrumKit/PumpManager/ConnectAttempt.swift
+++ b/MedtrumKit/PumpManager/ConnectAttempt.swift
@@ -38,6 +38,12 @@ final class ConnectAttempt {
         completions.append(completion)
     }
 
+    func takeCompletions() -> [(MedtrumConnectError?) -> Void] {
+        let waiting = completions
+        completions = []
+        return waiting
+    }
+
     /// True for the first caller only - whoever gets it owns reporting the result.
     func claim() -> Bool {
         guard !reported else {

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -42,6 +42,11 @@ public class MedtrumPumpManager: DeviceManager {
         bluetooth.pumpManager = self
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        log.info("MedtrumPumpManager deallocated")
+    }
+
     /// background sync, doesn't lock loops
     static let heartbeatSyncFreshnessInterval: TimeInterval = .minutes(2.5)
 

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -20,7 +20,7 @@ public class MedtrumPumpManager: DeviceManager {
         state.rawValue
     }
 
-    let bluetooth: BluetoothManager
+    var bluetooth: BluetoothManager!
     init(state: MedtrumPumpState) {
         self.state = state
         oldState = MedtrumPumpState(rawValue: state.rawValue)
@@ -45,6 +45,11 @@ public class MedtrumPumpManager: DeviceManager {
     deinit {
         NotificationCenter.default.removeObserver(self)
         log.info("MedtrumPumpManager deallocated")
+    }
+
+    public func forgetBluetoothManager() {
+        bluetooth?.pumpManager = nil
+        bluetooth = nil
     }
 
     /// background sync, doesn't lock loops

--- a/MedtrumKit/PumpManager/PeripheralManager.swift
+++ b/MedtrumKit/PumpManager/PeripheralManager.swift
@@ -4,8 +4,8 @@ class PeripheralManager: NSObject {
     private let log = MedtrumLogger(category: "PeripheralManager")
 
     private let peripheral: CBPeripheral
-    private let bluetoothManager: BluetoothManager
-    private let pumpManager: MedtrumPumpManager
+    private weak var bluetoothManager: BluetoothManager?
+    private weak var pumpManager: MedtrumPumpManager?
     private var completion: ((MedtrumConnectError?) -> Void)?
 
     private var readCharacteristic: CBCharacteristic?
@@ -63,7 +63,7 @@ class PeripheralManager: NSObject {
     }
 
     private func disconnectIfActive() {
-        bluetoothManager.disconnect(ifCurrent: self)
+        bluetoothManager?.disconnect(ifCurrent: self)
     }
 
     var isReady: Bool {
@@ -140,6 +140,10 @@ class PeripheralManager: NSObject {
 extension PeripheralManager {
     // Connect step 1
     private func doAuthorize(useBackupToken: Bool = false) {
+        guard let pumpManager else {
+            return
+        }
+
         let token = !useBackupToken ? pumpManager.state.sessionToken : pumpManager.state.backupSessionToken
         let authData = writePacket(
             AuthorizePacket(pumpSN: pumpManager.state.pumpSN, sessionToken: token)
@@ -216,13 +220,17 @@ extension PeripheralManager {
             isReadyStorage = true
             stateLock.unlock()
 
-            pumpManager.state.isConnected = true
-            pumpManager.notifyStateDidChange()
+            pumpManager?.state.isConnected = true
+            pumpManager?.notifyStateDidChange()
             completion?(nil)
         }
     }
 
     private func parseStateUpdate(_ syncResponse: SynchronizePacketResponse, duringReconnect: Bool, fullSync: Bool) {
+        guard let pumpManager else {
+            return
+        }
+
         guard !isInvalidatedLocked else {
             return
         }
@@ -328,7 +336,7 @@ extension PeripheralManager: CBPeripheralDelegate {
             if data[1] != 0x00 {
                 handleHeartbeat(data: data)
             } else {
-                pumpManager.issueHeartbeatIfNeeded()
+                pumpManager?.issueHeartbeatIfNeeded()
             }
 
             considerFullSync()
@@ -430,6 +438,10 @@ extension PeripheralManager: CBPeripheralDelegate {
     }
 
     private func considerFullSync() {
+        guard let pumpManager else {
+            return
+        }
+
         let age = Date.now.timeIntervalSince(pumpManager.state.lastSync)
         guard age > MedtrumPumpManager.heartbeatSyncFreshnessInterval else {
             return
@@ -472,7 +484,10 @@ extension PeripheralManager: CBPeripheralDelegate {
                 }
 
                 self.parseStateUpdate(syncResponse, duringReconnect: false, fullSync: true)
-                StateSyncer.fetchPatchTimeIfStale(pumpManager: self.pumpManager)
+
+                if let pumpManager = self.pumpManager {
+                    StateSyncer.fetchPatchTimeIfStale(pumpManager: pumpManager)
+                }
             }
         }
     }

--- a/MedtrumKitUI/ViewController/MedtrumKitUICoordinator.swift
+++ b/MedtrumKitUI/ViewController/MedtrumKitUICoordinator.swift
@@ -319,6 +319,7 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
             return
         }
 
+        pumpManager.forgetBluetoothManager()
         pumpManager.notifyDelegateOfDeactivation {
             DispatchQueue.main.async {
                 self.pumpManager = nil

--- a/MedtrumKitUI/ViewController/MedtrumKitUICoordinator.swift
+++ b/MedtrumKitUI/ViewController/MedtrumKitUICoordinator.swift
@@ -27,6 +27,10 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
     private var allowDebugFeatures: Bool
     private let logger = MedtrumLogger(category: "MedtrumKitUICoordinator")
 
+    deinit {
+        logger.info("MedtrumKitUICoordinator deallocated")
+    }
+
     var pumpManagerOnboardingDelegate: (any LoopKitUI.PumpManagerOnboardingDelegate)?
     var completionDelegate: (any LoopKitUI.CompletionDelegate)?
 
@@ -106,12 +110,13 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
         switch screen {
         case .welcomeScreen:
             return hostingController(
-                rootView: OnboardingWelcomeView(nextStep: { self.navigateTo(.insulinTypeScreen) }),
+                rootView: OnboardingWelcomeView(nextStep: { [weak self] in self?.navigateTo(.insulinTypeScreen) }),
                 title: String(localized: "Welcome", comment: "welcome header")
             )
 
         case .insulinTypeScreen:
-            let nextStep: (InsulinType) -> Void = { insulinType in
+            let nextStep: (InsulinType) -> Void = { [weak self] insulinType in
+                guard let self else { return }
                 self.pumpManager?.state.insulinType = insulinType
                 self.pumpManager?.notifyStateDidChange()
 
@@ -132,7 +137,8 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
             )
 
         case .patchSettingsScreen:
-            let nextStep = {
+            let nextStep = { [weak self] in
+                guard let self else { return }
                 if let pumpManager = self.pumpManager, pumpManager.isOnboarded {
                     return
                 }
@@ -159,7 +165,7 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
             )
 
         case .deactivatePatchScreen:
-            let nextStep = { self.resetNavigationTo([.settingsScreen, .pumpBaseSettingsScreen]) }
+            let nextStep: () -> Void = { [weak self] in self?.resetNavigationTo([.settingsScreen, .pumpBaseSettingsScreen]) }
             let viewModel = DeactivatePatchViewModel(pumpManager, nextStep)
             return hostingController(
                 rootView: PatchDeactivationView(viewModel: viewModel),
@@ -167,7 +173,8 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
             )
 
         case .pumpBaseSettingsScreen:
-            let nextStep = {
+            let nextStep = { [weak self] in
+                guard let self else { return }
                 if let pumpManager = self.pumpManager {
                     pumpManager.state.isOnboarded = true
                     pumpManager.notifyStateDidChange()
@@ -192,9 +199,9 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
         case .patchPrimingScreen:
             let viewModel = PatchPrimingViewModel(
                 pumpManager,
-                { self.resetNavigationTo([.patchActivationScreen]) },
-                { self.navigateTo(.pumpBaseSettingsScreen) },
-                { self.resetNavigationTo([.settingsScreen]) }
+                { [weak self] in self?.resetNavigationTo([.patchActivationScreen]) },
+                { [weak self] in self?.navigateTo(.pumpBaseSettingsScreen) },
+                { [weak self] in self?.resetNavigationTo([.settingsScreen]) }
             )
             return hostingController(
                 rootView: PatchPrimingView(viewModel: viewModel)
@@ -205,8 +212,8 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
         case .patchActivationScreen:
             let viewModel = PatchActivationViewModel(
                 pumpManager,
-                { self.resetNavigationTo([.settingsScreen]) },
-                { self.navigateTo(.patchPrimingScreen) }
+                { [weak self] in self?.resetNavigationTo([.settingsScreen]) },
+                { [weak self] in self?.navigateTo(.patchPrimingScreen) }
             )
             return hostingController(
                 rootView: PatchActivationView(viewModel: viewModel)
@@ -215,29 +222,29 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
             )
 
         case .settingsScreen:
-            let toDeactivation = {
-                self.navigateTo(.deactivatePatchScreen)
+            let toDeactivation: () -> Void = { [weak self] in
+                self?.navigateTo(.deactivatePatchScreen)
             }
-            let toActivation: (Bool) -> Void = { alreadyPrimed in
-                self.navigateTo(alreadyPrimed ? .patchActivationScreen : .patchPrimingScreen)
+            let toActivation: (Bool) -> Void = { [weak self] alreadyPrimed in
+                self?.navigateTo(alreadyPrimed ? .patchActivationScreen : .patchPrimingScreen)
             }
-            let toSettings = {
-                self.navigateTo(.patchSettingsScreen)
+            let toSettings: () -> Void = { [weak self] in
+                self?.navigateTo(.patchSettingsScreen)
             }
-            let toTempBasal = {
-                self.navigateTo(.manualTempBasalScreen)
+            let toTempBasal: () -> Void = { [weak self] in
+                self?.navigateTo(.manualTempBasalScreen)
             }
-            let toPatchDetails = {
-                self.navigateTo(.patchDetailsScreen)
+            let toPatchDetails: () -> Void = { [weak self] in
+                self?.navigateTo(.patchDetailsScreen)
             }
-            let toPreviousPatchDetails = {
-                self.navigateTo(.patchPreviousDetailsScreen)
+            let toPreviousPatchDetails: () -> Void = { [weak self] in
+                self?.navigateTo(.patchPreviousDetailsScreen)
             }
-            let toInsulinType = {
-                self.navigateTo(.insulinTypeScreen)
+            let toInsulinType: () -> Void = { [weak self] in
+                self?.navigateTo(.insulinTypeScreen)
             }
-            let toActivatePatch = {
-                self.navigateTo(.pumpBaseSettingsScreen)
+            let toActivatePatch: () -> Void = { [weak self] in
+                self?.navigateTo(.pumpBaseSettingsScreen)
             }
 
             let viewModel = MedtrumKitSettingsViewModel(
@@ -249,7 +256,7 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
                 toPatchDetails,
                 toPreviousPatchDetails,
                 toInsulinType,
-                pumpRemoval,
+                { [weak self] in self?.pumpRemoval() },
                 toActivatePatch
             )
             return hostingController(
@@ -314,6 +321,7 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
 
         pumpManager.notifyDelegateOfDeactivation {
             DispatchQueue.main.async {
+                self.pumpManager = nil
                 completionDelegate.completionNotifyingDidComplete(self)
             }
         }


### PR DESCRIPTION
Fixes https://github.com/jbr7rr/MedtrumKit/issues/191

We have a cycle of strong references between managers, preventing the `CentralManager` from deallocating, so when the pump manager is removed in the host app - the `CentralManager` remains allocated and alive. If the pump manager is add back within one session - we create a second copy of `CentralManager` with the same identifier, which is forbidden, and thus it will have state=`.unsupported` - scanning will not work (nothing will work?).

This PR is larger than I expected, but all the changes are about replacing strong references with weak ones.

The resulting retention "cycle" now look like this:

```
  MedtrumPumpManager ──owns──▶ BluetoothManager ──owns──▶ PeripheralManager
          ◀──weak──────────────────────┘  ◀──weak────────────────┘
          ◀──weak───────────────────────────────────────────────┘
```

```
  BluetoothManager ──owns──▶ ConnectAttempt ──▶ completions ──▶ MedtrumPumpManager
                                   ▲                  (released on report)
                                   └── weak ── PeripheralManager.completion
```

```
  MedtrumKitUICoordinator ──owns──▶ viewControllers ──▶ view models
          ◀────────── weak (12 closures) ──────────────────┘
```

A quick test on the phone showed all three managers dealocating when the pump manager is removed:
```
MedtrumKitUICoordinator.swift - deinit#31: MedtrumKitUICoordinator deallocated
MedtrumPumpManager.swift - deinit#47: MedtrumPumpManager deallocated
BluetoothManager.swift - deinit#37: BluetoothManager deallocated
```

And adding it back without restarting the app prints the normal state for the central manager:
```
BluetoothManager.swift - centralManagerDidUpdateState(_:)#433: 5
```
(state=5, not 2)


/cc @bastiaanv @mountrcg
