### PR TITLE
patch status checks

### DIFF
--- a/Common/OSLog.swift
+++ b/Common/OSLog.swift
@@ -1,11 +1,19 @@
 import Combine
+import Foundation
 import LoopKit
 import OSLog
 
 class MedtrumLogger {
     private let logger: Logger
     private let writer = MedtrumLogWriter.shared
-    public static var pumpManager: MedtrumPumpManager?
+    private static let pumpManagerLock = NSLock()
+
+    private static weak var pumpManagerStorage: MedtrumPumpManager?
+
+    public static var pumpManager: MedtrumPumpManager? {
+        get { pumpManagerLock.withLock { pumpManagerStorage } }
+        set { pumpManagerLock.withLock { pumpManagerStorage = newValue } }
+    }
 
     init(category: String) {
         logger = Logger(subsystem: "org.nightscout.MedtrumKit", category: category)
@@ -48,18 +56,25 @@ class MedtrumLogger {
     }
     
     private func writeToPumpManager(_ msg: String, _ type: OSLogEntryLog.Level) {
+        guard type != .debug else {
+            return
+        }
+
         guard let pumpManager = Self.pumpManager else {
             return
         }
-        
+
+        // `logDeviceIdentifier` is a snapshot that is safe to read from any thread.
+        let identifier = pumpManager.logDeviceIdentifier
+
         pumpManager.pumpDelegate.notify { delegate in
             guard let delegate else {
                 return
             }
-            
+
             delegate.deviceManager(
                 pumpManager,
-                logEventForDeviceIdentifier: pumpManager.state.pumpSN.hexEncodedString(),
+                logEventForDeviceIdentifier: identifier,
                 type: .delegate,
                 message: "[\(self.getLevel(type))] \(msg)",
             ) { _ in }

--- a/MedtrumKit/Packets/Enums/PatchState.swift
+++ b/MedtrumKit/Packets/Enums/PatchState.swift
@@ -76,3 +76,93 @@ public enum PatchState: UInt8, Codable {
         }
     }
 }
+
+extension PatchState {
+    enum Phase {
+        case setup
+        case running
+        case terminated
+    }
+
+    var phase: Phase {
+        switch self {
+        case .ejected,
+             .ejecting,
+             .filled,
+             .idle,
+             .none,
+             .primed,
+             .priming:
+            return .setup
+
+        case .active,
+             .active_alt,
+             .autoSuspended,
+             .dailyMaxSuspended,
+             .hourlyMaxSuspended,
+             .lowBgSuspended,
+             .lowBgSuspended2,
+             .paused,
+             .suspended:
+            return .running
+
+        case .baseFault,
+             .batteryOut,
+             .expired,
+             .noCalibration,
+             .occlusion,
+             .patchFault,
+             .patchFaultd2,
+             .reservoirEmpty,
+             .stopped:
+            return .terminated
+        }
+    }
+
+    var isSetup: Bool { phase == .setup }
+
+    var isRunning: Bool { phase == .running }
+
+    var isTerminated: Bool { phase == .terminated }
+
+    var isSuspended: Bool {
+        switch self {
+        case .autoSuspended,
+             .dailyMaxSuspended,
+             .hourlyMaxSuspended,
+             .lowBgSuspended,
+             .lowBgSuspended2,
+             .paused,
+             .suspended:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var isBeforePriming: Bool {
+        switch self {
+        case .filled,
+             .idle,
+             .none:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var hasCompletedPriming: Bool {
+        switch self {
+        case .ejected,
+             .ejecting,
+             .primed:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var isAwaitingActivation: Bool {
+        self != .none && isSetup
+    }
+}

--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -462,7 +462,7 @@ extension BluetoothManager {
             return
         }
 
-        if !isConnectedOnQueue, pumpManager?.state.pumpState == .active {
+        if !isConnectedOnQueue, pumpManager?.state.pumpState.isRunning == true {
             ensureConnectedOnQueue { error in
                 if let error = error {
                     self.logger.error("Failed to auto reconnect on boot: \(error)")

--- a/MedtrumKit/PumpManager/BluetoothManager.swift
+++ b/MedtrumKit/PumpManager/BluetoothManager.swift
@@ -37,7 +37,17 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
         logger.info("BluetoothManager deallocated")
     }
 
-    override init() {
+    /// The identifier we were paired with when the central was created. `CBCentralManager` can
+    /// deliver `willRestoreState` on `managerQueue` the moment it exists - which is inside
+    /// `MedtrumPumpManager.init`, before that initialiser reaches `bluetooth.pumpManager = self` - so
+    /// restoration cannot rely on reading the identifier off `pumpManager`. It is only read while
+    /// validating restoration, which happens once at creation and therefore before anything can
+    /// change it; `pumpManager` is the authority everywhere else.
+    private let identifierAtLaunch: UUID?
+
+    init(knownPeripheralIdentifier: UUID?) {
+        identifierAtLaunch = knownPeripheralIdentifier
+
         super.init()
 
         managerQueue.sync {
@@ -232,6 +242,7 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
         if let peripheral = peripheral {
             // We've the peripheral reference to a previous connection
             // Just try to reconnect
+            logger.info("Reconnecting to the peripheral of the previous connection")
             startTimeout(attempt, seconds: .seconds(15))
             connect(peripheral: peripheral)
             return
@@ -251,14 +262,6 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
             return
         }
 
-        let connectedDevices = manager.retrieveConnectedPeripherals(withServices: [CBUUID.SERVICE_UUID])
-        if let peripheral = connectedDevices.first(where: { $0.name == "MT" }) {
-            // Phone is already connected, but the app is not
-            startTimeout(attempt, seconds: .seconds(15))
-            connect(peripheral: peripheral)
-            return
-        }
-
         guard var pumpSNState = pumpManager?.state.pumpSN else {
             logger.error("No pump serial number found")
             finish(attempt, .failedToFindDevice)
@@ -269,6 +272,7 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate {
 
         // We are disconnected and have no reference to the previous connection
         // Start to scan for patch and reconnect the long way
+        logger.info("No known peripheral, scanning for the base with our serial number")
         startTimeout(attempt, seconds: .seconds(15))
         startScan { [weak self] result in
             guard let self else {
@@ -600,18 +604,30 @@ extension BluetoothManager {
 
     func centralManager(_ centralManager: CBCentralManager, willRestoreState dict: [String: Any]) {
         let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] ?? []
-        guard let peripheral = peripherals.first else {
+        guard !peripherals.isEmpty else {
             logger.warning("No restored peripherals!")
             return
         }
 
-        if peripheral.services?.first(where: { $0.uuid == CBUUID.SERVICE_UUID }) == nil {
-            logger.warning("Couldnt restore state, since no service is available...")
-            centralManager.cancelPeripheralConnection(peripheral)
-            return
-        }
+        // `pumpManager` is usually still nil here - see `identifierAtLaunch`.
+        let knownIdentifier = pumpManager?.state.peripheralIdentifier ?? identifierAtLaunch
 
-        self.peripheral = peripheral
+        for peripheral in peripherals {
+            if peripheral.services?.first(where: { $0.uuid == CBUUID.SERVICE_UUID }) == nil {
+                logger.warning("Couldnt restore state, since no service is available...")
+                centralManager.cancelPeripheralConnection(peripheral)
+                continue
+            }
+
+            guard peripheral.identifier == knownIdentifier else {
+                logger.warning("Dropping restored peripheral \(peripheral.identifier): not our known base")
+                centralManager.cancelPeripheralConnection(peripheral)
+                continue
+            }
+
+            logger.info("Restored our known base \(peripheral.identifier)")
+            self.peripheral = peripheral
+        }
     }
 
     func centralManager(_: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -24,7 +24,7 @@ public class MedtrumPumpManager: DeviceManager {
     init(state: MedtrumPumpState) {
         self.state = state
         oldState = MedtrumPumpState(rawValue: state.rawValue)
-        bluetooth = BluetoothManager()
+        bluetooth = BluetoothManager(knownPeripheralIdentifier: state.peripheralIdentifier)
         
         NotificationCenter.default.addObserver(
             self,

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -250,7 +250,7 @@ public extension MedtrumPumpManager {
             return
         }
 
-        guard state.pumpState.rawValue >= PatchState.active.rawValue else {
+        guard !state.pumpState.isSetup else {
             log.error("(ensureCurrentPumpData) patch not in active state yet")
             completion?(nil)
             return
@@ -706,8 +706,14 @@ public extension MedtrumPumpManager {
                 return
             }
 
-            guard self.state.pumpState.rawValue < PatchState.priming.rawValue else {
-                self.log.info("Patch already activated!")
+            guard !self.state.pumpState.isTerminated else {
+                self.log.error("Cannot prime, patch session is over: \(self.state.pumpState.description)")
+                completion(.failure(error: .patchNotPrimeable(state: self.state.pumpState)))
+                return
+            }
+
+            guard self.state.pumpState.isBeforePriming else {
+                self.log.info("Patch is already priming or primed!")
                 completion(.success)
                 return
             }
@@ -734,7 +740,13 @@ public extension MedtrumPumpManager {
                 return
             }
 
-            guard self.state.pumpState.rawValue < PatchState.active.rawValue else {
+            guard !self.state.pumpState.isTerminated else {
+                self.log.error("Cannot activate, patch session is over: \(self.state.pumpState.description)")
+                completion(.failure(error: .patchNotActivatable(state: self.state.pumpState)))
+                return
+            }
+
+            guard !self.state.pumpState.isRunning else {
                 self.log.info("Patch already activated!")
                 completion(.success)
                 return
@@ -1081,7 +1093,7 @@ public extension MedtrumPumpManager {
     }
 
     private func ensureConnectedAndActive(_ completion: @escaping (MedtrumConnectError?) -> Void) {
-        guard state.pumpState.rawValue >= PatchState.active.rawValue else {
+        guard !state.pumpState.isSetup else {
             log.warning("No active patch, failing immediately")
             completion(.failedToFindDevice)
             return

--- a/MedtrumKit/PumpManager/MedtrumPumpManager.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpManager.swift
@@ -20,11 +20,25 @@ public class MedtrumPumpManager: DeviceManager {
         state.rawValue
     }
 
+    private let logDeviceIdentifierLock = NSLock()
+    private var logDeviceIdentifierStorage = ""
+
+    /// for host-app logging
+    var logDeviceIdentifier: String {
+        logDeviceIdentifierLock.withLock { logDeviceIdentifierStorage }
+    }
+
+    private func refreshLogDeviceIdentifier() {
+        let identifier = state.pumpSN.hexEncodedString()
+        logDeviceIdentifierLock.withLock { logDeviceIdentifierStorage = identifier }
+    }
+
     var bluetooth: BluetoothManager!
     init(state: MedtrumPumpState) {
         self.state = state
         oldState = MedtrumPumpState(rawValue: state.rawValue)
         bluetooth = BluetoothManager(knownPeripheralIdentifier: state.peripheralIdentifier)
+        refreshLogDeviceIdentifier()
         
         NotificationCenter.default.addObserver(
             self,
@@ -959,6 +973,8 @@ public extension MedtrumPumpManager {
     }
 
     func notifyStateDidChange() {
+        refreshLogDeviceIdentifier()
+
         DispatchQueue.main.async {
             let status = self.status(self.state)
             let oldStatus = self.status(self.oldState)
@@ -1119,7 +1135,7 @@ public extension MedtrumPumpManager {
         // Not dispatching here; if delegate queue is blocked, timestamps will be delayed
         pumpManagerDelegate?.deviceManager(
             self,
-            logEventForDeviceIdentifier: state.pumpSN.hexEncodedString(),
+            logEventForDeviceIdentifier: logDeviceIdentifier,
             type: type,
             message: message,
             completion: nil

--- a/MedtrumKit/PumpManager/MedtrumPumpState.swift
+++ b/MedtrumKit/PumpManager/MedtrumPumpState.swift
@@ -210,7 +210,16 @@ public class MedtrumPumpState: RawRepresentable {
     public var isOnboarded: Bool
     public var insulinType: InsulinType?
     public var lastSync: Date
-    public var pumpSN: Data
+    public var pumpSN: Data {
+        didSet {
+            guard pumpSN != oldValue else {
+                return
+            }
+
+            // prevent ensureConnected from reconnecting straight back to the previous base
+            peripheralIdentifier = nil
+        }
+    }
     public var lowReservoirWarning: Double?
     public var useSilentTones: Bool
 

--- a/MedtrumKit/PumpManager/Models/MedtrumActivatePatchResult.swift
+++ b/MedtrumKit/PumpManager/Models/MedtrumActivatePatchResult.swift
@@ -5,12 +5,15 @@ public enum MedtrumActivatePatchResult {
 
 public enum MedtrumActivatePatchError: LocalizedError {
     case connectionFailure(reason: String)
+    case patchNotActivatable(state: PatchState)
     case unknownError(reason: String)
 
     public var errorDescription: String? {
         switch self {
         case let .connectionFailure(reason: reason):
             return "Connection failure: \(reason)"
+        case let .patchNotActivatable(state: state):
+            return "This patch can no longer be activated (\(state.description)). Please replace it with a new patch."
         case let .unknownError(reason: reason):
             return "Unknown error: \(reason)"
         }

--- a/MedtrumKit/PumpManager/Models/MedtrumPrimePatchResult.swift
+++ b/MedtrumKit/PumpManager/Models/MedtrumPrimePatchResult.swift
@@ -7,6 +7,7 @@ public enum MedtrumPrimePatchError: LocalizedError {
     case needToDeactivateFirst
     case connectionFailure(reason: String)
     case noKnownPumpBase
+    case patchNotPrimeable(state: PatchState)
     case unknownError(reason: LocalizedError)
 
     var description: String {
@@ -17,6 +18,8 @@ public enum MedtrumPrimePatchError: LocalizedError {
             return "Pump base is currently active. Please deactivate it first."
         case .noKnownPumpBase:
             return "No known pump base found."
+        case let .patchNotPrimeable(state: state):
+            return "This patch can no longer be primed (\(state.description)). Please replace it with a new patch."
         case let .unknownError(reason: reason):
             return "Unknown error: \(reason)"
         }

--- a/MedtrumKitUI/MedtrumKitPumpManager+UI.swift
+++ b/MedtrumKitUI/MedtrumKitPumpManager+UI.swift
@@ -114,7 +114,7 @@ extension MedtrumPumpManager: PumpManagerUI {
                 imageName: "exclamationmark.circle.fill",
                 state: .critical
             )
-        } else if state.pumpState.rawValue > PatchState.active_alt.rawValue {
+        } else if state.pumpState.isSuspended || state.pumpState.isTerminated {
             return PumpStatusHighlight(
                 localizedMessage: String(
                     localized: "Patch Error",

--- a/MedtrumKitUI/ViewController/MedtrumKitUICoordinator.swift
+++ b/MedtrumKitUI/ViewController/MedtrumKitUICoordinator.swift
@@ -91,18 +91,21 @@ class MedtrumKitUICoordinator: UINavigationController, PumpManagerOnboarding, Co
             return [.welcomeScreen]
         }
 
-        if pumpManager.state.pumpState.rawValue < PatchState.priming.rawValue {
+        let pumpState = pumpManager.state.pumpState
+
+        if pumpState.isBeforePriming {
             return [.settingsScreen, .pumpBaseSettingsScreen]
         }
 
-        if pumpManager.state.pumpState.rawValue < PatchState.primed.rawValue {
+        if pumpState == .priming {
             return [.patchPrimingScreen]
         }
 
-        if pumpManager.state.pumpState.rawValue < PatchState.active.rawValue {
+        if pumpState.hasCompletedPriming {
             return [.patchActivationScreen]
         }
 
+        // running or terminated
         return [.settingsScreen]
     }
 

--- a/MedtrumKitUI/ViewModels/Onboarding/PatchPrimingViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Onboarding/PatchPrimingViewModel.swift
@@ -58,7 +58,7 @@ class PatchPrimingViewModel: ObservableObject {
                     return
                 }
 
-                if pumpManager.state.pumpState.rawValue >= PatchState.primed.rawValue {
+                if pumpManager.state.pumpState.hasCompletedPriming || pumpManager.state.pumpState.isRunning {
                     DispatchQueue.main.async {
                         self.nextStep()
                     }
@@ -89,15 +89,20 @@ extension PatchPrimingViewModel: PumpManagerStatusObserver {
             DispatchQueue.main.async {
                 self.primeProgress = Double(pumpManager.state.primeProgress) / 240
 
-                if pumpManager.state.pumpState.rawValue > PatchState.priming.rawValue,
-                   pumpManager.state.pumpState.rawValue < PatchState.active.rawValue
-                {
+                let pumpState = pumpManager.state.pumpState
+
+                if pumpState.hasCompletedPriming {
                     pumpManager.removeStatusObserver(self)
                     self.nextStep()
-                } else if pumpManager.state.pumpState.rawValue >= PatchState.active.rawValue {
+                } else if pumpState.isRunning {
                     // Patch already activated, ready to jump to settings
                     pumpManager.removeStatusObserver(self)
                     self.done()
+                } else if pumpState.isTerminated {
+                    self.isPriming = false
+                    self.primingError = MedtrumPrimePatchError
+                        .patchNotPrimeable(state: pumpState)
+                        .description
                 }
             }
         #endif

--- a/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
+++ b/MedtrumKitUI/ViewModels/Settings/MedtrumKitSettingsViewModel.swift
@@ -269,8 +269,7 @@ class MedtrumKitSettingsViewModel: PatchLifetimeFormatting, ObservableObject, Pu
             return
         }
 
-        let alreadyPrimed = pumpManager.state.pumpState.rawValue >= PatchState.primed.rawValue
-        pumpActivationAction(alreadyPrimed)
+        pumpActivationAction(pumpManager.state.pumpState.hasCompletedPriming)
     }
 
     func suspendDelivery(duration: TimeInterval) {

--- a/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
+++ b/MedtrumKitUI/Views/Settings/MedtrumKitSettings.swift
@@ -220,7 +220,7 @@ struct MedtrumKitSettings: View {
                         }
                     }
 
-                    if viewModel.patchState.rawValue < PatchState.active.rawValue && viewModel.patchState != .none {
+                    if viewModel.patchState.isAwaitingActivation {
                         Button(action: { viewModel.toPumpActivation() }) {
                             HStack {
                                 Text("Activate Patch", comment: "label for activate patch")


### PR DESCRIPTION
Related to https://github.com/jbr7rr/MedtrumKit/issues/162

The reported issue happened on a (much) older commit, so it's hard to tell if the latest `dev` branch would have worked better for the user. Nevertheless, the issue surfaced a couple of potential problems:

##  patch state is checked using ordinal values
 
`pumpState.rawValue < PatchState.active.rawValue` etc

This is fine in most cases, but, for example, when the user wants to activate a new patch, and the current patch state is one of the error states - the `pumpState >= PatchState.active` condition will pass and the user will be sent back to the previous screen.

To fix this, all "arithmetic" checks are replaced with a set of computed vars on the `PatchState`:
* `isSetup`
* `isRunning`
* `isTerminated`
* `isSuspended`
* `isBeforePriming`
* `hasCompletedPriming`
* `isAwaitingActivation`

## multiple connected bases 

The user reports that while troubleshooting, they've been trying to connect to two patch bases. It is unclear if both bases were ever powered on at the same time, but this case is problematic: we have this "optimistic" connect path - list devices already connected to the phone, and pick the first one that has name = "MT". The problem is - we don't check the serial number in this case (it is not available) and the pump manager can connect to a wrong base. It will start receiving status notifications from it, but the subsequent authentication and commands will be failing.

To fix this, this connect path is removed completely (if there is no peripheral/identifier - a scan will be always attempted, which does verify the serial number).

Additionally, in the `willRestoreState` callback from the central manager, we verify the peripherals against the known identifier. Changing the serial number also clears the saved peripheral identifier.

## A crash in the logger

After removing the pump manager and adding it back, I had a full app crash (in the logger, trying to concurrently access the `static var pumpManager` - `Simultaneous accesses to 0x10437ba40, but modification requires exclusive access.`).

This code has been updated to use a lock-protected device-identifier snapshot and a weak reference to the pump manager. Also, debug messages are no longer forwarded to the host app.